### PR TITLE
Track repeated junctions to merge transitives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ staph:
 	@echo "cluster    staph"; \
 	pangraph cluster -d data/staph data/staph/assemblies/*.fna.gz
 	@echo "build      staph"; \
-	pangraph build -d data/staph -m 500 -b 0 data/staph/guide.json 1>data/staph/pangraph.json
+	pangraph build -d data/staph -m 500 -b 0 data/staph/guide.json # 1>data/staph/pangraph.json
 
 # figures
 

--- a/pangraph/block.py
+++ b/pangraph/block.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.random as rng
 
-from collections import defaultdict
+from collections import defaultdict, Counter
 from .utils import parse_cigar, wcpair, as_array, as_string
 
 # ------------------------------------------------------------------------
@@ -47,7 +47,7 @@ class Block(object):
 
     @property
     def isolates(self):
-        return list(set([ k[0] for k in self.muts.keys() ]))
+        return dict(Counter([k[0] for k in self.muts]))
 
     # ------------------
     # static methods

--- a/pangraph/block.py
+++ b/pangraph/block.py
@@ -75,7 +75,7 @@ class Block(object):
 
     @classmethod
     def cat(cls, blks):
-        nblk = cls()
+        nblk = Block()
         assert all([blks[0].muts.keys() == b2.muts.keys() for b2 in blks[1:]])
 
         nblk.seq  = np.concatenate([b.seq for b in blks])

--- a/pangraph/block.py
+++ b/pangraph/block.py
@@ -28,6 +28,12 @@ class Block(object):
         self.seq  = None
         self.muts = {}
 
+    def __str__(self):
+        return str(self.id)
+
+    def __repr__(self):
+        return str(self)
+
     # ------------------
     # properties
 

--- a/pangraph/build.py
+++ b/pangraph/build.py
@@ -71,12 +71,10 @@ def main(args):
     mkdir(tmp)
 
     log("aligning")
-    with cProfile.Profile() as pr:
-        T.align(tmp, args.len, args.mu, args.beta, args.extensive, args.statistics)
-        # TODO: when debugging phase is done, remove tmp directory
+    T.align(tmp, args.len, args.mu, args.beta, args.extensive, args.statistics)
+    # TODO: when debugging phase is done, remove tmp directory
 
-        graphs = T.collect()
-    pr.dump_stats("perf.prof")
+    graphs = T.collect()
 
     for i, g in enumerate(graphs):
         log(f"graph {i}: nseqs: {len(g.seqs)} nblks: {len(g.blks)}")

--- a/pangraph/build.py
+++ b/pangraph/build.py
@@ -3,7 +3,6 @@ build a pangenome alignment from an annotated guide tree
 """
 import os, sys
 import builtins
-import cProfile
 
 from .utils import mkdir, log
 from .tree import Tree

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -25,29 +25,28 @@ EXTEND = 2500
 
 class Junction(object):
     def __init__(self, left, right):
-        self.left  = (left.id, left.strand)
-        self.right = (right.id, right.strand)
-
-    def __eq__(self, other):
-        if self.left == other.left and self.right == other.right:
-            return True
-        revo = other.reverse()
-        if self.left == revo.left and self.right == revo.right:
-            return True
-
-        return False
+        self.left  = left
+        self.right = right
 
     @property
     def data(self):
-        return (self.left, self.right)
+        return ((self.left.blk.id, self.left.strand), (self.right.blk.id, self.right.strand))
+
+    def __eq__(self, other):
+        if self.data == other.data:
+            return True
+        elif self.data == other.reverse().data:
+            return False
+        else:
+            return False
 
     def __hash__(self):
-        return hash(frozenset([self.data, self.reverse.data]))
+        return hash(frozenset([self.data, self.reverse().data]))
 
     def reverse(self):
         return Junction(
-            Node(right.id, right.num, Strand(-1*right.strand)),
-            Node(left.id,  left.num,  Strand(-1*left.strand)),
+            Node(self.right.blk, self.right.num, Strand(-1*self.right.strand)),
+            Node(self.left.blk,  self.left.num,  Strand(-1*self.left.strand)),
         )
 
 # ------------------------------------------------------------------------
@@ -307,6 +306,7 @@ class Graph(object):
             #         print(subpath, file=sys.stderr)
             #         breakpoint("stop")
 
+        js = self.junctions()
         for path in self.seqs.values():
             path.rm_nil_blks()
 
@@ -317,7 +317,7 @@ class Graph(object):
     def junctions(self):
         junctions = defaultdict(list)
         for iso, path in self.seqs.items():
-            for i, n in path.nodes:
+            for i, n in enumerate(path.nodes):
                 j = Junction(path.nodes[i-1], n)
                 junctions[j].append(iso)
         print(junctions)

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -381,7 +381,7 @@ class Graph(object):
             elif j.left_id in chains:
                 c = chains[j.left_id]
                 if j.left_blk == c[-1]:
-                    c.append(j_right_blk)
+                    c.append(j.right_blk)
                 elif rev_blk(j.left_blk) == c[0]:
                     c.insert(0, rev_blk(j.right_blk))
                 else:
@@ -398,7 +398,7 @@ class Graph(object):
                 chains[j.left_id]  = [j.left_blk, j.right_blk]
                 chains[j.right_id] = chains[j.left_id]
 
-        chains = set(chains.values())
+        chains = list({id(c):c for c in chains.values()}.values())
         print(chains)
 
     def prune_blks(self):

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -403,14 +403,14 @@ class Graph(object):
 
         chains = list({id(c):c for c in chains.values()}.values())
         for c in chains:
-            new_blk = Block.cat([self.blks[id] if s == Strand.Plus else self.blks[id].rev_cmpl() for id, s in c])
+            new_blk = Block.cat([self.blks[b] if s == Strand.Plus else self.blks[b].rev_cmpl() for b, s in c])
             # TODO: check that isos is constant along the chain
             for iso in self.blks[c[0][0]].isolates.keys():
-                self.seqs[iso].merge(c, new_blk)
+                self.seqs[iso].merge(c[0], c[-1], new_blk)
 
             self.blks[new_blk.id] = new_blk
-            for id, _ in c:
-                self.blks.pop(id)
+            for b, _ in c:
+                self.blks.pop(b)
 
     def prune_blks(self):
         blks = set()

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -407,6 +407,9 @@ class Graph(object):
             # TODO: check that isos is constant along the chain
             for iso in self.blks[c[0][0]].isolates.keys():
                 self.seqs[iso].merge(c[0], c[-1], new_blk)
+                for n in self.seqs[iso].nodes:
+                    if n.blk.id in [e[0] for e in c]:
+                        breakpoint("bad deletion")
 
             self.blks[new_blk.id] = new_blk
             for b, _ in c:

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -1,9 +1,10 @@
 import os, sys
 import json
 import numpy as np
+import pprint
 
 from glob        import glob
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 from Bio           import SeqIO, Phylo
 from Bio.Seq       import Seq
@@ -18,6 +19,7 @@ from .utils    import Strand, as_string, parse_paf, panic, as_record, new_strand
 # globals
 
 EXTEND = 2500
+pp = pprint.PrettyPrinter(indent=4)
 
 # ------------------------------------------------------------------------
 # Junction class
@@ -49,11 +51,30 @@ class Junction(object):
     def data(self):
         return ((self.left.blk.id, self.left.strand), (self.right.blk.id, self.right.strand))
 
+    @property
+    def right_id(self):
+        return self.right.blk.id
+
+    @property
+    def left_id(self):
+        return self.left.blk.id
+
+    @property
+    def left_blk(self):
+        return (self.left.blk.id, self.left.strand)
+
+    @property
+    def right_blk(self):
+        return (self.right.blk.id, self.right.strand)
+
     def reverse(self):
         return Junction(
             Node(self.right.blk, self.right.num, Strand(-1*self.right.strand)),
             Node(self.left.blk,  self.left.num,  Strand(-1*self.left.strand)),
         )
+
+def rev_blk(b):
+    return (b[0], Strand(-1*b[1]))
 
 # ------------------------------------------------------------------------
 # Graph class
@@ -311,24 +332,74 @@ class Graph(object):
             #         subpath = path[lb:ub]
             #         print(subpath, file=sys.stderr)
             #         breakpoint("stop")
+        self.remove_transitives()
 
-        js = self.junctions()
-        print(js)
-        breakpoint("junctions")
         for path in self.seqs.values():
             path.rm_nil_blks()
 
         return self, merged
 
     # a junction is a pair of adjacent blocks.
-    # by convention, we always have edges w/ + orientation for the first element
     def junctions(self):
         junctions = defaultdict(list)
         for iso, path in self.seqs.items():
             for i, n in enumerate(path.nodes):
                 j = Junction(path.nodes[i-1], n)
                 junctions[j].append(iso)
-        return dict(junctions)
+        return { k:dict(Counter(v)) for k, v in junctions.items() }
+
+    def remove_transitives(self):
+        js = self.junctions()
+        transitives = []
+        for j, isos in js.items():
+            left_eq_right = self.blks[j.left.blk.id].isolates == self.blks[j.right.blk.id].isolates
+            left_eq_isos  = isos == self.blks[j.left.blk.id].isolates
+            if left_eq_right and left_eq_isos:
+                transitives.append(j)
+
+        chains = {}
+        for j in transitives:
+            if j.left_id in chains and j.right_id in chains:
+                c1, c2 = chains[j.left_id], chains[j.right_id]
+                if c1 == c2:
+                    continue
+
+                if j.left_blk==c1[-1] and j.right_blk==c2[0]:
+                    new_chain = c1 + c2
+                elif j.left_blk==c1[-1] and rev_blk(j.right_blk)==c2[-1]:
+                    new_chain = c1 + [rev_blk(b) for b in c2[::-1]]
+                elif rev_blk(j.left_blk)==c1[0] and j.right_blk==c2[0]:
+                    new_chain = [rev_blk(b) for b in c1[::-1]] + c2
+                elif rev_blk(j.left_blk)==c1[0] and rev_blk(j.right_blk)==c2[-1]:
+                    new_chain = c2 + c1
+                else:
+                    breakpoint("case not covered")
+
+                for b, _ in new_chain:
+                    chains[b] = new_chain
+
+            elif j.left_id in chains:
+                c = chains[j.left_id]
+                if j.left_blk == c[-1]:
+                    c.append(j_right_blk)
+                elif rev_blk(j.left_blk) == c[0]:
+                    c.insert(0, rev_blk(j.right_blk))
+                else:
+                    breakpoint("chains should be linear")
+            elif j.right_id in chains:
+                c = chains[j.right_id]
+                if j.right_blk == c[-1]:
+                    c.append(rev_blk(j.left_blk))
+                elif j.right_blk == c[0]:
+                    c.insert(0, j.left_blk)
+                else:
+                    breakpoint("chains should be linear")
+            else:
+                chains[j.left_id]  = [j.left_blk, j.right_blk]
+                chains[j.right_id] = chains[j.left_id]
+
+        chains = set(chains.values())
+        print(chains)
 
     def prune_blks(self):
         blks = set()

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -28,10 +28,6 @@ class Junction(object):
         self.left  = left
         self.right = right
 
-    @property
-    def data(self):
-        return ((self.left.blk.id, self.left.strand), (self.right.blk.id, self.right.strand))
-
     def __eq__(self, other):
         if self.data == other.data:
             return True
@@ -42,6 +38,16 @@ class Junction(object):
 
     def __hash__(self):
         return hash(frozenset([self.data, self.reverse().data]))
+
+    def __str__(self):
+        return f"({self.left}, {self.right})"
+
+    def __repr__(self):
+        return str(self)
+
+    @property
+    def data(self):
+        return ((self.left.blk.id, self.left.strand), (self.right.blk.id, self.right.strand))
 
     def reverse(self):
         return Junction(
@@ -307,6 +313,8 @@ class Graph(object):
             #         breakpoint("stop")
 
         js = self.junctions()
+        print(js)
+        breakpoint("junctions")
         for path in self.seqs.values():
             path.rm_nil_blks()
 
@@ -320,8 +328,7 @@ class Graph(object):
             for i, n in enumerate(path.nodes):
                 j = Junction(path.nodes[i-1], n)
                 junctions[j].append(iso)
-        print(junctions)
-        return junctions
+        return dict(junctions)
 
     def prune_blks(self):
         blks = set()

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -403,9 +403,14 @@ class Graph(object):
 
         chains = list({id(c):c for c in chains.values()}.values())
         for c in chains:
-            print(c)
-        if len(chains) > 0:
-            breakpoint('test')
+            new_blk = Block.cat([self.blks[id] if s == Strand.Plus else self.blks[id].rev_cmpl() for id, s in c])
+            # TODO: check that isos is constant along the chain
+            for iso in self.blks[c[0][0]].isolates.keys():
+                self.seqs[iso].merge(c, new_blk)
+
+            self.blks[new_blk.id] = new_blk
+            for id, _ in c:
+                self.blks.pop(id)
 
     def prune_blks(self):
         blks = set()

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -343,6 +343,9 @@ class Graph(object):
     def junctions(self):
         junctions = defaultdict(list)
         for iso, path in self.seqs.items():
+            if len(path.nodes) == 1:
+                continue
+
             for i, n in enumerate(path.nodes):
                 j = Junction(path.nodes[i-1], n)
                 junctions[j].append(iso)
@@ -399,7 +402,10 @@ class Graph(object):
                 chains[j.right_id] = chains[j.left_id]
 
         chains = list({id(c):c for c in chains.values()}.values())
-        print(chains)
+        for c in chains:
+            print(c)
+        if len(chains) > 0:
+            breakpoint('test')
 
     def prune_blks(self):
         blks = set()

--- a/pangraph/graph.py
+++ b/pangraph/graph.py
@@ -407,9 +407,9 @@ class Graph(object):
             # TODO: check that isos is constant along the chain
             for iso in self.blks[c[0][0]].isolates.keys():
                 self.seqs[iso].merge(c[0], c[-1], new_blk)
-                for n in self.seqs[iso].nodes:
-                    if n.blk.id in [e[0] for e in c]:
-                        breakpoint("bad deletion")
+                # for n in self.seqs[iso].nodes:
+                #     if n.blk.id in [e[0] for e in c]:
+                #         breakpoint("bad deletion")
 
             self.blks[new_blk.id] = new_blk
             for b, _ in c:

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -77,7 +77,7 @@ class Path(object):
     def sequence(self, verbose=False):
         seq = ""
         for n in self.nodes:
-            s = n.blk.extract(self.name, n.num, strip_gaps=False, verbose=verbose)
+            s = n.blk.extract(self.name, n.num, strip_gaps=True, verbose=verbose)
             if n.strand == Strand.Plus:
                 seq += s
             else:
@@ -120,8 +120,6 @@ class Path(object):
             ids = [n.blk.id for n in self.nodes]
             try:
                 i, j = ids.index(start[0]), ids.index(stop[0])
-            except:
-                return
 
                 if self.nodes[i].strand == start[1]:
                     beg, end, s = i, j, Strand.Plus
@@ -136,6 +134,8 @@ class Path(object):
                 self.position  = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
 
                 N += 1
+            except:
+                return
 
     def replace(self, blk, tag, new_blks, blk_map):
         new = []

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -20,6 +20,12 @@ class Node(object):
     def __repr__(self):
         return str(self)
 
+    def __eq__(self, other):
+        return self.blk.id == other.blk.id and self.strand == other.strand
+
+    def __hash__(self):
+        return hash((self.blk.id, self.strand))
+
     @classmethod
     def from_dict(cls, d, blks):
         N = Node()

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -113,6 +113,23 @@ class Path(object):
         self.nodes    = [self.nodes[i] for i in good]
         self.position = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
 
+    # TODO: deal w/ multiple runs!!
+    def merge(self, start, stop, new):
+        ids  = [n.blk.id for n in self.nodes]
+        i, j = ids.index(start[0]), ids.index(stop[0])
+
+        if self.nodes[i].strand == start[1]:
+            beg, end, s = i, j, Strand.Plus
+        else:
+            beg, end, s = j, i, Strand.Minus
+
+        if beg < end:
+            self.nodes = self.nodes[:beg] + [Node(new, 0, s)] + self.nodes[end+1:]
+        else:
+            self.offset += sum(n.blk.len_of(self.name, 0) for n in self.nodes[beg:])
+            self.nodes = [Node(new, 0, s)] + self.nodes[end+1:beg]
+        self.position = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
+
     def replace(self, blk, tag, new_blks, blk_map):
         new = []
         for n in self.nodes:

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -14,6 +14,12 @@ class Node(object):
         self.num    = num
         self.strand = strand
 
+    def __str__(self):
+        return f"({self.blk}, {self.num}, {self.strand})")
+
+    def __repr__(self):
+        return str(self)
+
     @classmethod
     def from_dict(cls, d, blks):
         N = Node()
@@ -40,6 +46,12 @@ class Path(object):
         self.nodes    = nodes if isinstance(nodes, list) else [nodes]
         self.offset   = offset
         self.position = np.cumsum([0] + [n.length(name) for n in self.nodes])
+
+    def __str__(self):
+        return f"{self.name}: {[str(n) for n in self.nodes]}"
+
+    def __repr__(self):
+        return str(self)
 
     @classmethod
     def from_dict(cls, d):

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -115,9 +115,9 @@ class Path(object):
 
     # TODO: debug cases w/ multiple runs
     def merge(self, start, stop, new):
-        ids  = [n.blk.id for n in self.nodes]
-        off, n  = 0, 0
+        N = 0
         while True:
+            ids = [n.blk.id for n in self.nodes]
             try:
                 i, j = ids.index(start[0]), ids.index(stop[0])
 
@@ -127,14 +127,13 @@ class Path(object):
                     beg, end, s = j, i, Strand.Minus
 
                 if beg < end:
-                    self.nodes = self.nodes[:beg] + [Node(new, 0, s)] + self.nodes[end+1:]
+                    self.nodes = self.nodes[:beg] + [Node(new, N, s)] + self.nodes[end+1:]
                 else:
-                    self.offset += sum(n.blk.len_of(self.name, 0) for n in self.nodes[beg:])
-                    self.nodes = [Node(new, 0, s)] + self.nodes[end+1:beg]
+                    self.offset += sum(n.blk.len_of(self.name, N) for n in self.nodes[beg:])
+                    self.nodes = [Node(new, N, s)] + self.nodes[end+1:beg]
                 self.position  = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
 
-                off = max(i, j)
-                n  += 1
+                N += 1
             except:
                 return
 

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -120,6 +120,8 @@ class Path(object):
             ids = [n.blk.id for n in self.nodes]
             try:
                 i, j = ids.index(start[0]), ids.index(stop[0])
+            except:
+                return
 
                 if self.nodes[i].strand == start[1]:
                     beg, end, s = i, j, Strand.Plus
@@ -134,8 +136,6 @@ class Path(object):
                 self.position  = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
 
                 N += 1
-            except:
-                return
 
     def replace(self, blk, tag, new_blks, blk_map):
         new = []

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -15,7 +15,7 @@ class Node(object):
         self.strand = strand
 
     def __str__(self):
-        return f"({self.blk}, {self.num}, {self.strand})")
+        return f"({self.blk}, {self.num}, {self.strand})"
 
     def __repr__(self):
         return str(self)

--- a/pangraph/sequence.py
+++ b/pangraph/sequence.py
@@ -113,22 +113,30 @@ class Path(object):
         self.nodes    = [self.nodes[i] for i in good]
         self.position = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
 
-    # TODO: deal w/ multiple runs!!
+    # TODO: debug cases w/ multiple runs
     def merge(self, start, stop, new):
         ids  = [n.blk.id for n in self.nodes]
-        i, j = ids.index(start[0]), ids.index(stop[0])
+        off, n  = 0, 0
+        while True:
+            try:
+                i, j = ids.index(start[0]), ids.index(stop[0])
 
-        if self.nodes[i].strand == start[1]:
-            beg, end, s = i, j, Strand.Plus
-        else:
-            beg, end, s = j, i, Strand.Minus
+                if self.nodes[i].strand == start[1]:
+                    beg, end, s = i, j, Strand.Plus
+                else:
+                    beg, end, s = j, i, Strand.Minus
 
-        if beg < end:
-            self.nodes = self.nodes[:beg] + [Node(new, 0, s)] + self.nodes[end+1:]
-        else:
-            self.offset += sum(n.blk.len_of(self.name, 0) for n in self.nodes[beg:])
-            self.nodes = [Node(new, 0, s)] + self.nodes[end+1:beg]
-        self.position = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
+                if beg < end:
+                    self.nodes = self.nodes[:beg] + [Node(new, 0, s)] + self.nodes[end+1:]
+                else:
+                    self.offset += sum(n.blk.len_of(self.name, 0) for n in self.nodes[beg:])
+                    self.nodes = [Node(new, 0, s)] + self.nodes[end+1:beg]
+                self.position  = np.cumsum([0] + [n.length(self.name) for n in self.nodes])
+
+                off = max(i, j)
+                n  += 1
+            except:
+                return
 
     def replace(self, blk, tag, new_blks, blk_map):
         new = []

--- a/pangraph/tree.py
+++ b/pangraph/tree.py
@@ -304,6 +304,7 @@ class Tree(object):
                 rec  = G.extract(n.name)
                 uncompressed_length += len(orig)
                 if orig != rec:
+                    breakpoint("inconsistency")
                     nerror += 1
 
                     with open("test.fa", "w+") as out:

--- a/pangraph/tree.py
+++ b/pangraph/tree.py
@@ -320,15 +320,15 @@ class Tree(object):
                             pos   = [0]
                             seq   = G.seqs[n.name]
                             for nn in seq.nodes:
-                                pos.append(pos[-1] + len(G.blks[nn.id].extract(n.name, nn.num)))
+                                pos.append(pos[-1] + len(G.blks[nn.blk.id].extract(n.name, nn.num)))
                             pos = pos[1:]
 
                             testseqs = []
                             for nn in G.seqs[n.name].nodes:
                                 if nn.strand == Strand.Plus:
-                                    testseqs.append("".join(G.blks[nn.id].extract(n.name, nn.num)))
+                                    testseqs.append("".join(G.blks[nn.blk.id].extract(n.name, nn.num)))
                                 else:
-                                    testseqs.append("".join(rev_cmpl(G.blks[nn.id].extract(n.name, nn.num))))
+                                    testseqs.append("".join(rev_cmpl(G.blks[nn.blk.id].extract(n.name, nn.num))))
 
             if nerror == 0:
                 log("all sequences correctly reconstructed")


### PR DESCRIPTION
Analysis of sliced blocks from the previous feature addition shows that we have a surplus of transitive edges that need to be merged. As of now they cause a lot of unnecessary fragmentation.