### PR TITLE
perf: more par_iter

### DIFF
--- a/packages/pangraph/src/align/minimap2_lib/align_with_minimap2_lib.rs
+++ b/packages/pangraph/src/align/minimap2_lib/align_with_minimap2_lib.rs
@@ -17,7 +17,7 @@ pub fn align_with_minimap2_lib(
   params: &AlignmentArgs,
 ) -> Result<Vec<Alignment>, Report> {
   let (names, seqs): (Vec<String>, Vec<&str>) = blocks
-    .iter()
+    .par_iter()
     .map(|(id, block)| (id.to_string(), block.consensus()))
     .unzip();
 
@@ -70,7 +70,7 @@ fn align_with_minimap2_lib_impl(
     .collect::<Result<Vec<_>, Report>>()?;
 
   let alns = results
-    .into_iter()
+    .into_par_iter()
     .map(Alignment::from_minimap_paf_obj)
     .collect::<Result<Vec<Vec<_>>, Report>>()?
     .into_iter()
@@ -85,7 +85,7 @@ impl Alignment {
   pub fn from_minimap_paf_obj(res: Minimap2Result) -> Result<Vec<Self>, Report> {
     let Minimap2Result { pafs, .. } = res;
     pafs
-      .into_iter()
+      .into_par_iter()
       .map(|paf| {
         if let Some(cg) = &paf.cg {
           Ok(Alignment {

--- a/packages/pangraph/src/pangraph/graph_merging.rs
+++ b/packages/pangraph/src/pangraph/graph_merging.rs
@@ -104,7 +104,7 @@ pub fn self_merge(graph: Pangraph, args: &PangraphBuildArgs) -> Result<(Pangraph
   // - whenever an alignment contains an in/del longer than the threshold length
   //   (parameter - default 100 bp) we want to split the alignment in two)
   let matches = matches
-    .iter()
+    .par_iter()
     .filter(|m| m.qry.name != m.reff.name)
     .map(|m| split_matches(m, &args.aln_args))
     .collect::<Result<Vec<Vec<Alignment>>, Report>>()?
@@ -189,9 +189,11 @@ pub fn filter_matches(alns: &[Alignment], args: &AlignmentArgs) -> Vec<Alignment
   // TODO: energy is calculated for each alignment.
   // Consider calculating it earlier and making it a property to simplify filtering and sorting.
   let alns = alns
-    .iter()
+    .par_iter()
     .map(|aln| (aln, alignment_energy2(aln, args)))
     .filter(|(_, energy)| energy < &0.0)
+    .collect::<Vec<_>>()
+    .into_iter()
     .sorted_by_key(|(_, energy)| OrderedFloat(*energy))
     .map(|(aln, _)| aln)
     .collect_vec();

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -86,17 +86,17 @@ impl ToMerge {
 }
 
 fn assign_new_block_ids(mergers: &mut [Alignment]) {
-  for a in mergers.iter_mut() {
+  mergers.par_iter_mut().for_each(|a| {
     debug_assert!(a.new_block_id.is_none());
     a.new_block_id = Some(BlockId(
       // FIXME: looks like this is trying to calculate its own hash id? It should probably not be done in random places like this.
       id((&a.qry.name, &a.qry.interval, &a.reff.name, &a.reff.interval)),
     ));
-  }
+  });
 }
 
 fn assign_anchor_block(mergers: &mut [Alignment], graph: &Pangraph) {
-  for m in mergers.iter_mut() {
+  mergers.par_iter_mut().for_each(|m| {
     let ref_block = &graph.blocks[&m.reff.name];
     let qry_block = &graph.blocks[&m.qry.name];
     if ref_block.depth() >= qry_block.depth() {
@@ -104,7 +104,7 @@ fn assign_anchor_block(mergers: &mut [Alignment], graph: &Pangraph) {
     } else {
       m.anchor_block = Some(AnchorBlock::Qry);
     }
-  }
+  });
 }
 
 fn target_blocks(mergers: &[Alignment]) -> BTreeMap<BlockId, Vec<Alignment>> {


### PR DESCRIPTION
Similar to https://github.com/neherlab/pangraph/pull/107 but less succesful.

Here I tried to introduce more parallelism in random places where I found `.iter()` or a a plain loop and where rayon's `.par_iter()` could be used (technically; scientific correctness is to be verified).

In my measurements this brings no speedup at all compared to base branch.

I'll just leave this as an idea for the future optimization. Perhaps there's a smarter way to find places where we can  squeeze some more parallelism, or we could restructure the algo such that new parallelization opportunities appear.

At the time, this is low priority I think, so let's focus on other things.