### PR TITLE
feat: use ASCII char and special container for sequences

### DIFF
--- a/packages/pangraph/src/align/minimap2_lib/align_with_minimap2_lib.rs
+++ b/packages/pangraph/src/align/minimap2_lib/align_with_minimap2_lib.rs
@@ -18,7 +18,7 @@ pub fn align_with_minimap2_lib(
 ) -> Result<Vec<Alignment>, Report> {
   let (names, seqs): (Vec<String>, Vec<&str>) = blocks
     .iter()
-    .map(|(id, block)| (id.to_string(), block.consensus()))
+    .map(|(id, block)| (id.to_string(), block.consensus().as_str()))
     .unzip();
 
   let alns: Vec<Alignment> = align_with_minimap2_lib_impl(&seqs, &names, params)?;
@@ -171,7 +171,7 @@ mod tests {
 
     let fasta = read_many_fasta_str(fasta)?;
 
-    let (seqs, names): (Vec<String>, Vec<String>) = fasta.into_iter().map(|f| (f.seq, f.seq_name)).unzip();
+    let (seqs, names): (Vec<String>, Vec<String>) = fasta.into_iter().map(|f| (f.seq.to_string(), f.seq_name)).unzip();
 
     let params = AlignmentArgs {
       kmer_length: Some(10),

--- a/packages/pangraph/src/bin/minimap2_example.rs
+++ b/packages/pangraph/src/bin/minimap2_example.rs
@@ -6,6 +6,7 @@ use pangraph::align::alignment_args::AlignmentArgs;
 use pangraph::align::minimap2::align_with_minimap2::align_with_minimap2;
 use pangraph::io::fasta::read_many_fasta;
 use pangraph::pangraph::pangraph_block::{BlockId, PangraphBlock};
+use pangraph::representation::seq_char::AsciiChar;
 use pangraph::utils::global_init::global_init;
 use std::path::PathBuf;
 
@@ -33,7 +34,10 @@ fn main() -> Result<(), Report> {
     .into_iter()
     .map(|r| r.seq)
     .enumerate()
-    .map(|(i, seq)| PangraphBlock::new(BlockId(i), seq.replace(['\n', ' '], ""), btreemap! {}))
+    .map(|(i, mut seq)| {
+      seq.retain(|c| ![AsciiChar(b'\n'), AsciiChar(b' ')].contains(c));
+      PangraphBlock::new(BlockId(i), seq, btreemap! {})
+    })
     .map(|block| (block.id(), block))
     .collect();
 

--- a/packages/pangraph/src/bin/minimap2_lib_example.rs
+++ b/packages/pangraph/src/bin/minimap2_lib_example.rs
@@ -11,6 +11,7 @@ use pangraph::io::json::{json_write_file, JsonPretty};
 use pangraph::utils::global_init::global_init;
 use rayon::prelude::*;
 use std::path::PathBuf;
+use pangraph::representation::seq::Seq;
 
 #[ctor]
 fn init() {
@@ -20,7 +21,7 @@ fn init() {
 fn main() -> Result<(), Report> {
   let cli = Minimap2CliArgs::parse();
 
-  let (names, seqs): (Vec<String>, Vec<String>) = read_many_fasta(&cli.input_fastas)?
+  let (names, seqs): (Vec<String>, Vec<Seq>) = read_many_fasta(&cli.input_fastas)?
     .into_iter()
     .map(|f| (f.seq_name, f.seq))
     .unzip();

--- a/packages/pangraph/src/bin/mmseqs_example.rs
+++ b/packages/pangraph/src/bin/mmseqs_example.rs
@@ -6,6 +6,7 @@ use pangraph::align::alignment_args::AlignmentArgs;
 use pangraph::align::mmseqs::align_with_mmseqs::align_with_mmseqs;
 use pangraph::io::fasta::read_many_fasta;
 use pangraph::pangraph::pangraph_block::{BlockId, PangraphBlock};
+use pangraph::representation::seq_char::AsciiChar;
 use pangraph::utils::global_init::global_init;
 use std::path::PathBuf;
 
@@ -33,7 +34,10 @@ fn main() -> Result<(), Report> {
     .into_iter()
     .map(|r| r.seq)
     .enumerate()
-    .map(|(i, seq)| PangraphBlock::new(BlockId(i), seq.replace(['\n', ' '], ""), btreemap! {}))
+    .map(|(i, mut seq)| {
+      seq.retain(|c| ![AsciiChar(b'\n'), AsciiChar(b' ')].contains(c));
+      PangraphBlock::new(BlockId(i), seq, btreemap! {})
+    })
     .map(|block| (block.id(), block))
     .collect();
 

--- a/packages/pangraph/src/circularize/merge_blocks.rs
+++ b/packages/pangraph/src/circularize/merge_blocks.rs
@@ -6,6 +6,7 @@ use eyre::Report;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 
+use crate::representation::seq::Seq;
 #[cfg(any(debug_assertions, test))]
 use log::warn;
 
@@ -128,7 +129,7 @@ fn concatenate_alignments(
 ) -> PangraphBlock {
   debug_assert!(bl1.depth() == bl2.depth(), "blocks must have the same depth");
 
-  let seq = [bl1.consensus(), bl2.consensus()].concat();
+  let seq = Seq::concat(&[bl1.consensus(), bl2.consensus()]);
 
   let mut aln = btreemap! {};
   for (&nid1, e1) in bl1.alignments() {
@@ -166,7 +167,7 @@ fn check_sequence_reconstruction(
     let seq2 = e2.apply(block_2.consensus())?;
 
     // concatenate
-    let seq = [seq1, seq2].concat();
+    let seq = Seq::concat(&[&seq1, &seq2]);
 
     // reconstruct new sequence
     let new_id = new_nodes_id[&nid1];

--- a/packages/pangraph/src/commands/reconstruct/reconstruct_run.rs
+++ b/packages/pangraph/src/commands/reconstruct/reconstruct_run.rs
@@ -6,7 +6,7 @@ use crate::make_internal_report;
 use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::pangraph_node::NodeId;
 use crate::pangraph::pangraph_path::PangraphPath;
-use crate::utils::string_rotate::StringRotateRight;
+use crate::representation::seq::Seq;
 use eyre::Report;
 use itertools::Itertools;
 use log::info;
@@ -35,7 +35,7 @@ pub fn reconstruct_run(args: &PangraphReconstructArgs) -> Result<(), Report> {
     let mut writer = FastaWriter::from_path(output_fasta)?;
     results.try_for_each(|fasta| {
       let fasta = fasta?;
-      writer.write(fasta.seq_name, fasta.seq)
+      writer.write(fasta.seq_name, &fasta.seq)
     })?;
   }
 
@@ -63,15 +63,15 @@ pub fn reconstruct(graph: &Pangraph) -> impl Iterator<Item = Result<FastaRecord,
     })
 }
 
-fn reconstruct_path_sequence(graph: &Pangraph, path: &PangraphPath) -> Result<String, Report> {
+fn reconstruct_path_sequence(graph: &Pangraph, path: &PangraphPath) -> Result<Seq, Report> {
   if let Some(first_node_id) = path.nodes.first() {
     let first_node_pos = graph.nodes[first_node_id].position().0;
 
-    let mut genome: String = path
+    let mut genome: Seq = path
       .nodes
       .iter()
       .map(|node_id| reconstruct_block_sequence(graph, *node_id))
-      .collect::<Result<String, Report>>()?;
+      .collect::<Result<Seq, Report>>()?;
 
     let genome_len = path.tot_len();
     assert_eq!(genome.len(), genome_len);
@@ -80,11 +80,11 @@ fn reconstruct_path_sequence(graph: &Pangraph, path: &PangraphPath) -> Result<St
 
     Ok(genome)
   } else {
-    Ok(String::new())
+    Ok(Seq::new())
   }
 }
 
-fn reconstruct_block_sequence(graph: &Pangraph, node_id: NodeId) -> Result<String, Report> {
+fn reconstruct_block_sequence(graph: &Pangraph, node_id: NodeId) -> Result<Seq, Report> {
   let node = graph
     .nodes
     .get(&node_id)
@@ -103,7 +103,7 @@ fn reconstruct_block_sequence(graph: &Pangraph, node_id: NodeId) -> Result<Strin
 
   // Reverse-complement if on opposite strand
   if node.strand().is_reverse() {
-    s = reverse_complement(s)?;
+    s = reverse_complement(&s)?;
   }
   Ok(s)
 }

--- a/packages/pangraph/src/distance/mash/mash_distance.rs
+++ b/packages/pangraph/src/distance/mash/mash_distance.rs
@@ -70,6 +70,7 @@ mod tests {
   use crate::io::fasta::FastaRecord;
   use crate::o;
   use crate::pangraph::strand::Strand::Forward;
+  use crate::representation::seq::Seq;
   use ndarray::array;
   use pretty_assertions::assert_eq;
   use rstest::rstest;
@@ -78,7 +79,7 @@ mod tests {
     Pangraph::singleton(
       FastaRecord {
         seq_name: o!(""),
-        seq: seq.as_ref().to_owned(),
+        seq: Seq::from_str(seq.as_ref()),
         index: 0,
       },
       Forward,

--- a/packages/pangraph/src/io/fasta.rs
+++ b/packages/pangraph/src/io/fasta.rs
@@ -2,6 +2,7 @@ use crate::io::compression::Decompressor;
 use crate::io::concat::Concat;
 use crate::io::file::{create_file_or_stdout, open_file_or_stdin, open_stdin};
 use crate::make_error;
+use crate::representation::seq::Seq;
 use eyre::Report;
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -20,7 +21,7 @@ pub fn is_char_allowed(c: char) -> bool {
 #[serde(rename_all = "camelCase")]
 pub struct FastaRecord {
   pub seq_name: String,
-  pub seq: String,
+  pub seq: Seq,
   pub index: usize,
 }
 
@@ -184,7 +185,7 @@ pub fn read_many_fasta<P: AsRef<Path>>(filepaths: &[P]) -> Result<Vec<FastaRecor
 
   loop {
     let mut record = FastaRecord::default();
-    reader.read(&mut record).unwrap();
+    reader.read(&mut record)?;
     if record.is_empty() {
       break;
     }
@@ -207,7 +208,7 @@ pub fn read_many_fasta_str(contents: impl AsRef<str>) -> Result<Vec<FastaRecord>
 
   loop {
     let mut record = FastaRecord::default();
-    reader.read(&mut record).unwrap();
+    reader.read(&mut record)?;
     if record.is_empty() {
       break;
     }
@@ -231,8 +232,8 @@ impl FastaWriter {
     Ok(Self::new(create_file_or_stdout(filepath)?))
   }
 
-  pub fn write(&mut self, seq_name: impl AsRef<str>, seq: impl AsRef<str>) -> Result<(), Report> {
-    write!(self.writer, ">{}\n{}\n", seq_name.as_ref(), seq.as_ref())?;
+  pub fn write(&mut self, seq_name: impl AsRef<str>, seq: &Seq) -> Result<(), Report> {
+    write!(self.writer, ">{}\n{}\n", seq_name.as_ref(), seq)?;
     Ok(())
   }
 
@@ -242,11 +243,7 @@ impl FastaWriter {
   }
 }
 
-pub fn write_one_fasta(
-  filepath: impl AsRef<Path>,
-  seq_name: impl AsRef<str>,
-  seq: impl AsRef<str>,
-) -> Result<(), Report> {
+pub fn write_one_fasta(filepath: impl AsRef<Path>, seq_name: impl AsRef<str>, seq: &Seq) -> Result<(), Report> {
   let mut writer = FastaWriter::from_path(&filepath)?;
   writer.write(seq_name, seq)
 }
@@ -409,7 +406,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("a"),
-        seq: o!("ACGCTCGATC"),
+        seq: Seq::from("ACGCTCGATC"),
         index: 0,
       }
     );
@@ -420,7 +417,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("b"),
-        seq: o!("CCGCGC"),
+        seq: Seq::from("CCGCGC"),
         index: 1,
       }
     );
@@ -438,7 +435,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("a"),
-        seq: o!("ACGCTCGATC"),
+        seq: Seq::from("ACGCTCGATC"),
         index: 0,
       }
     );
@@ -449,7 +446,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("b"),
-        seq: o!("CCGCGC"),
+        seq: Seq::from("CCGCGC"),
         index: 1,
       }
     );
@@ -460,7 +457,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("c"),
-        seq: o!(""),
+        seq: Seq::from(""),
         index: 2,
       }
     );
@@ -478,7 +475,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("a"),
-        seq: o!("ACGCTCGATC"),
+        seq: Seq::from("ACGCTCGATC"),
         index: 0,
       }
     );
@@ -489,7 +486,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("b"),
-        seq: o!(""),
+        seq: Seq::from(""),
         index: 1,
       }
     );
@@ -500,7 +497,7 @@ mod tests {
       record,
       FastaRecord {
         seq_name: o!("c"),
-        seq: o!("CCGCGC"),
+        seq: Seq::from("CCGCGC"),
         index: 2,
       }
     );

--- a/packages/pangraph/src/io/gfa.rs
+++ b/packages/pangraph/src/io/gfa.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Write;
 use std::path::Path;
+use crate::representation::seq::Seq;
 
 #[derive(Parser, Debug, Default, Clone)]
 pub struct GfaWriteParams {
@@ -86,7 +87,7 @@ pub fn gfa_write<W: Write>(mut writer: W, g: &Pangraph, params: &GfaWriteParams)
 
   for segment in gfa.segments.values() {
     let segment_seq = if params.include_sequences() {
-      &segment.sequence
+      segment.sequence.as_str()
     } else {
       "*"
     };
@@ -145,7 +146,7 @@ pub struct Gfa {
 #[derive(Debug, Clone)]
 pub struct GfaSegment {
   name: BlockId,
-  sequence: String,
+  sequence: Seq,
   depth: usize,
   length: usize,
   duplicated: bool,

--- a/packages/pangraph/src/io/seq.rs
+++ b/packages/pangraph/src/io/seq.rs
@@ -1,43 +1,41 @@
 use crate::make_error;
+use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 use eyre::Report;
 use rand::seq::SliceRandom;
 use rand::Rng;
 
-pub fn complement(nuc: char) -> Result<char, Report> {
-  Ok(match nuc {
-    'A' => 'T',
-    'C' => 'G',
-    'G' => 'C',
-    'T' => 'A',
-    'Y' => 'R',
-    'R' => 'Y',
-    'W' => 'W',
-    'S' => 'S',
-    'K' => 'M',
-    'M' => 'K',
-    'D' => 'H',
-    'V' => 'B',
-    'H' => 'D',
-    'B' => 'V',
-    'N' => 'N',
-    '-' => '-',
+pub fn complement(nuc: &AsciiChar) -> Result<AsciiChar, Report> {
+  Ok(match *nuc {
+    AsciiChar(b'A') => AsciiChar(b'T'),
+    AsciiChar(b'C') => AsciiChar(b'G'),
+    AsciiChar(b'G') => AsciiChar(b'C'),
+    AsciiChar(b'T') => AsciiChar(b'A'),
+    AsciiChar(b'Y') => AsciiChar(b'R'),
+    AsciiChar(b'R') => AsciiChar(b'Y'),
+    AsciiChar(b'W') => AsciiChar(b'W'),
+    AsciiChar(b'S') => AsciiChar(b'S'),
+    AsciiChar(b'K') => AsciiChar(b'M'),
+    AsciiChar(b'M') => AsciiChar(b'K'),
+    AsciiChar(b'D') => AsciiChar(b'H'),
+    AsciiChar(b'V') => AsciiChar(b'B'),
+    AsciiChar(b'H') => AsciiChar(b'D'),
+    AsciiChar(b'B') => AsciiChar(b'V'),
+    AsciiChar(b'N') => AsciiChar(b'N'),
+    AsciiChar(b'-') => AsciiChar(b'-'),
     _ => return make_error!("Unknown nucleotide character: '{nuc}'"),
   })
 }
 
-pub fn reverse_complement(seq: impl AsRef<str>) -> Result<String, Report> {
-  seq
-    .as_ref()
-    .chars()
-    .rev()
-    .map(complement)
-    .collect::<Result<String, Report>>()
+pub fn reverse_complement(seq: &Seq) -> Result<Seq, Report> {
+  seq.iter().rev().map(complement).collect::<Result<Seq, Report>>()
 }
 
-pub fn generate_random_nuc_sequence(length: usize, rng: &mut impl Rng) -> String {
+pub fn generate_random_nuc_sequence(length: usize, rng: &mut impl Rng) -> Seq {
   const CHOICES: [char; 4] = ['A', 'C', 'G', 'T'];
   (0..length)
     .map(|_| CHOICES.choose(rng).expect("choosing from an empty set"))
+    .map(|c| AsciiChar::from(*c))
     .collect()
 }
 
@@ -50,17 +48,17 @@ mod tests {
 
   #[test]
   fn test_reverse_complement() -> Result<(), Report> {
-    assert_eq!(reverse_complement("ATCG")?, "CGAT");
-    assert_eq!(reverse_complement("GATTACA")?, "TGTAATC");
-    assert_eq!(reverse_complement("ACGTYRWSKM")?, "KMSWYRACGT");
-    assert_eq!(reverse_complement("N-")?, "-N");
+    assert_eq!(reverse_complement(&Seq::from("ATCG"))?, "CGAT");
+    assert_eq!(reverse_complement(&Seq::from("GATTACA"))?, "TGTAATC");
+    assert_eq!(reverse_complement(&Seq::from("ACGTYRWSKM"))?, "KMSWYRACGT");
+    assert_eq!(reverse_complement(&Seq::from("N-"))?, "-N");
     Ok(())
   }
 
   #[test]
   fn test_reverse_complement_invalid() {
     assert_eq!(
-      reverse_complement("ATCGX").unwrap_err().to_string(),
+      reverse_complement(&Seq::from("ATCGX")).unwrap_err().to_string(),
       "Unknown nucleotide character: 'X'"
     );
   }

--- a/packages/pangraph/src/lib.rs
+++ b/packages/pangraph/src/lib.rs
@@ -5,6 +5,7 @@ pub mod distance;
 pub mod io;
 pub mod pangraph;
 pub mod reconsensus;
+pub mod representation;
 pub mod tree;
 pub mod utils;
 

--- a/packages/pangraph/src/pangraph/edits.rs
+++ b/packages/pangraph/src/pangraph/edits.rs
@@ -1,5 +1,6 @@
 use crate::io::seq::{complement, reverse_complement};
-use crate::utils::collections::insert_at_inplace;
+use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 use crate::utils::interval::Interval;
 use eyre::Report;
 use itertools::Itertools;
@@ -14,18 +15,18 @@ use eyre::eyre;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema)]
 pub struct Sub {
   pub pos: usize,
-  pub alt: char,
+  pub alt: AsciiChar,
 }
 
 impl Sub {
-  pub fn new(pos: usize, alt: char) -> Self {
-    Self { pos, alt }
+  pub fn new(pos: usize, alt: impl Into<AsciiChar>) -> Self {
+    Self { pos, alt: alt.into() }
   }
 
   pub fn reverse_complement(&self, len: usize) -> Result<Self, Report> {
     Ok(Self {
       pos: len - self.pos - 1,
-      alt: complement(self.alt)?,
+      alt: complement(&self.alt)?,
     })
   }
 
@@ -84,15 +85,12 @@ impl Del {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd, Hash, JsonSchema)]
 pub struct Ins {
   pub pos: usize,
-  pub seq: String,
+  pub seq: Seq,
 }
 
 impl Ins {
-  pub fn new(pos: usize, seq: impl AsRef<str>) -> Self {
-    Self {
-      pos,
-      seq: seq.as_ref().to_owned(),
-    }
+  pub fn new(pos: usize, seq: impl Into<Seq>) -> Self {
+    Self { pos, seq: seq.into() }
   }
 
   pub fn reverse_complement(&self, len: usize) -> Result<Self, Report> {
@@ -179,7 +177,7 @@ impl Edit {
     // concatenate self + next
     for ins in &next.inss {
       if let Some(prev) = inss.iter_mut().find(|i| i.pos == ins.pos) {
-        prev.seq.push_str(&ins.seq);
+        prev.seq.extend_seq(&ins.seq);
       } else {
         inss.push(ins.clone());
       }
@@ -191,9 +189,8 @@ impl Edit {
   }
 
   /// Apply the edits to the reference to obtain the query sequence
-  pub fn apply(&self, reff: impl AsRef<str>) -> Result<String, Report> {
-    // TODO: decide whether it's best to use chars, bytes of something else entirely
-    let mut qry: Vec<char> = reff.as_ref().chars().collect_vec();
+  pub fn apply(&self, reff: impl Into<Seq>) -> Result<Seq, Report> {
+    let mut qry = reff.into();
 
     for sub in &self.subs {
       qry[sub.pos] = sub.alt;
@@ -202,26 +199,22 @@ impl Edit {
     for del in &self.dels {
       // Replace deleted nucs with character `-`, to avoid frame shift
       for pos in del.range() {
-        qry[pos] = '-';
+        qry[pos] = AsciiChar(b'-');
       }
     }
 
     for ins in self.inss.iter().sorted().rev() {
-      // TODO: avoid copy
-      let seq = ins.seq.chars().collect_vec();
-      insert_at_inplace(&mut qry, ins.pos, &seq);
+      qry.insert_seq(ins.pos, &ins.seq);
     }
 
     // Strip gaps introduced when applying deletions
-    qry.retain(|c| c != &'-');
+    qry.retain(|c| c != &AsciiChar(b'-'));
 
-    let qry = String::from_iter(&qry);
     Ok(qry)
   }
 
-  pub fn apply_aligned(&self, reff: impl AsRef<str>) -> Result<String, Report> {
-    // TODO: decide whether it's best to use chars, bytes of something else entirely
-    let mut qry: Vec<char> = reff.as_ref().chars().collect_vec();
+  pub fn apply_aligned(&self, reff: impl Into<Seq>) -> Result<Seq, Report> {
+    let mut qry = reff.into();
 
     for sub in &self.subs {
       qry[sub.pos] = sub.alt;
@@ -229,18 +222,17 @@ impl Edit {
 
     for del in &self.dels {
       for pos in del.range() {
-        qry[pos] = '-';
+        qry[pos] = AsciiChar(b'-');
       }
     }
 
-    let qry = String::from_iter(&qry);
     Ok(qry)
   }
 
   /// Check if the alignment is empty, i.e. after applying the edits to the
   /// consensus sequence, the resulting sequence is empty.
-  pub fn is_empty_alignment(&self, consensus: impl AsRef<str>) -> bool {
-    let cons_len = consensus.as_ref().len();
+  pub fn is_empty_alignment(&self, consensus: &Seq) -> bool {
+    let cons_len = consensus.len();
     // if there are insertions, the alignment is not empty
     let insertions_len = self.inss.iter().map(|i| i.seq.len()).sum::<usize>();
     if insertions_len > 0 {
@@ -269,7 +261,7 @@ impl Edit {
           len
         ));
       }
-      if sub.alt == '-' {
+      if sub.alt == AsciiChar(b'-') {
         return Err(eyre!("Substitution with deletion character '-' is not allowed"));
       }
     }
@@ -365,7 +357,7 @@ mod tests {
     let edits = Edit { subs, dels, inss };
 
     let actual = edits.apply(r).unwrap();
-    assert_eq!(q, actual);
+    assert_eq!(q, &actual);
   }
 
   #[rstest]
@@ -382,7 +374,7 @@ mod tests {
     };
 
     let actual = edits.apply(r).unwrap();
-    assert_eq!(q, actual);
+    assert_eq!(q, &actual);
   }
 
   #[rstest]
@@ -399,7 +391,7 @@ mod tests {
     };
 
     let actual = edits.apply(r).unwrap();
-    assert_eq!(q, actual);
+    assert_eq!(q, &actual);
   }
 
   #[rstest]
@@ -417,27 +409,27 @@ mod tests {
     };
 
     let actual = edits.apply(r).unwrap();
-    assert_eq!(q, actual);
+    assert_eq!(q, &actual);
   }
 
   #[rstest]
   fn test_empty_alignment() {
     let consensus = "ACGT";
     let edits = Edit::empty();
-    assert!(!edits.is_empty_alignment(consensus));
+    assert!(!edits.is_empty_alignment(&Seq::from(consensus)));
 
     let edits = Edit {
       subs: vec![],
       dels: vec![Del::new(0, 4)],
       inss: vec![Ins::new(1, "A")],
     };
-    assert!(!edits.is_empty_alignment(consensus));
+    assert!(!edits.is_empty_alignment(&Seq::from(consensus)));
 
     let edits = Edit {
       subs: vec![],
       dels: vec![Del::new(0, 4)],
       inss: vec![],
     };
-    assert!(edits.is_empty_alignment(consensus));
+    assert!(edits.is_empty_alignment(&Seq::from(consensus)));
   }
 }

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::str::FromStr;
+use crate::representation::seq::Seq;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Hash, PartialEq, Eq, JsonSchema)]
 pub struct Pangraph {
@@ -52,7 +53,7 @@ impl Pangraph {
     Ok(tree_str)
   }
 
-  pub fn consensuses(&self) -> impl Iterator<Item = &str> {
+  pub fn consensuses(&self) -> impl Iterator<Item = &Seq> {
     self.blocks.values().map(|block| block.consensus())
   }
 

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -46,7 +46,7 @@ impl MergePromise {
         let edits = if seq.is_empty() {
           Edit::deleted(self.anchor_block.consensus().len())
         } else {
-          map_variations(self.anchor_block.consensus(), seq)?
+          map_variations(self.anchor_block.consensus(), &seq)?
         };
 
         #[cfg(any(test, debug_assertions))]
@@ -297,6 +297,7 @@ mod tests {
   use maplit::{btreemap, btreeset};
   use noodles::sam::record::Cigar;
   use pretty_assertions::assert_eq;
+  use crate::representation::seq::Seq;
 
   #[test]
   fn test_extract_hits() {
@@ -638,6 +639,7 @@ mod tests {
 
     assert_eq!(u.b_new.len(), 1);
     let b = &u.b_new[0];
+
     assert_eq!(b.consensus(), &G.blocks[&bid].consensus()[50..80]);
     assert_eq!(b.alignment_keys(), node_keys_1);
 
@@ -662,7 +664,7 @@ mod tests {
   #[test]
   fn test_reweave() -> Result<(), Report> {
     fn i(pos: usize, len: usize, seq: impl AsRef<str>) -> Ins {
-      Ins::new(pos, seq.as_ref().repeat(len))
+      Ins::new(pos, Seq::from_str(&seq.as_ref().repeat(len)))
     }
 
     fn d(pos: usize, len: usize) -> Del {

--- a/packages/pangraph/src/reconsensus/reconsensus.rs
+++ b/packages/pangraph/src/reconsensus/reconsensus.rs
@@ -6,7 +6,8 @@ use crate::pangraph::pangraph_block::{BlockId, PangraphBlock};
 use crate::pangraph::pangraph_node::NodeId;
 // use crate::reconsensus::remove_nodes::remove_emtpy_nodes;
 use crate::reconsensus::remove_nodes::find_empty_nodes;
-use crate::utils::collections::insert_at_inplace;
+use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 use eyre::Report;
 use itertools::Itertools;
 use maplit::btreemap;
@@ -86,7 +87,7 @@ fn reconsensus_mutations(block: &mut PangraphBlock) -> Result<(), Report> {
 
   // apply change
   for (pos, alt) in changes {
-    let original = block.consensus().chars().nth(pos).unwrap();
+    let original = block.consensus()[pos];
 
     // update consensus
     block.set_consensus_char(pos, alt);
@@ -165,29 +166,31 @@ fn majority_insertions(block: &PangraphBlock) -> Vec<Ins> {
 }
 
 /// Updates the consensus sequence with the deletions and insertions.
-fn apply_indels(cons: &str, dels: &[usize], inss: &[Ins]) -> String {
-  let mut cons: Vec<char> = cons.chars().collect();
+fn apply_indels(cons: impl Into<Seq>, dels: &[usize], inss: &[Ins]) -> Seq {
+  let mut cons = cons.into();
 
   for &pos in dels {
-    cons[pos] = '\0'; // Using '\0' to temporarily denote deleted positions
+    cons[pos] = AsciiChar(b'\0'); // Using '\0' to temporarily denote deleted positions
   }
 
   // Reverse to maintain correct insertion indexes after each insert
   for Ins { pos, seq } in inss.iter().rev() {
-    insert_at_inplace(&mut cons, *pos, &seq.chars().collect_vec());
+    cons.insert_seq(*pos, seq);
   }
 
-  cons.into_iter().filter(|&c| c != '\0').collect()
+  cons.retain(|&c| c != AsciiChar(b'\0'));
+
+  cons
 }
 
 /// Updates the consensus sequence of the block and re-aligns the sequences to the new consensus.
-fn update_block_consensus(block: &mut PangraphBlock, consensus: impl Into<String> + AsRef<str>) -> Result<(), Report> {
+fn update_block_consensus(block: &mut PangraphBlock, consensus: &Seq) -> Result<(), Report> {
   // Reconstruct block sequences
   let seqs = block
     .alignments()
     .iter()
     .map(|(&nid, edit)| Ok((nid, edit.apply(block.consensus())?)))
-    .collect::<Result<BTreeMap<NodeId, String>, Report>>()?;
+    .collect::<Result<BTreeMap<NodeId, Seq>, Report>>()?;
 
   // debug assets: all sequences are non-empty
   #[cfg(any(debug_assertions, test))]
@@ -208,7 +211,7 @@ fn update_block_consensus(block: &mut PangraphBlock, consensus: impl Into<String
   // Re-align sequences
   let alignments = seqs
     .into_iter()
-    .map(|(nid, seq)| Ok((nid, map_variations(&consensus, &seq)?)))
+    .map(|(nid, seq)| Ok((nid, map_variations(consensus, &seq)?)))
     .collect::<Result<_, Report>>()?;
 
   *block = PangraphBlock::new(block.id(), consensus, alignments);
@@ -222,8 +225,8 @@ mod tests {
   use crate::pangraph::edits::{Del, Edit, Ins, Sub};
   use crate::pangraph::pangraph_block::PangraphBlock;
   use crate::pangraph::pangraph_node::NodeId;
-  use crate::pretty_assert_eq;
   use maplit::btreemap;
+  use pretty_assertions::assert_eq;
 
   fn block_1() -> PangraphBlock {
     let consensus = "AGGACTTCGATCTATTCGGAGAA";
@@ -314,19 +317,19 @@ mod tests {
     let mut block = block_1();
     let expected_block = block_1_mut_reconsensus();
     reconsensus_mutations(&mut block).unwrap();
-    pretty_assert_eq!(block, expected_block);
+    assert_eq!(block, expected_block);
   }
 
   #[test]
   fn test_majority_deletions() {
     let dels = majority_deletions(&block_2());
-    pretty_assert_eq!(dels, vec![5, 6, 20]);
+    assert_eq!(dels, vec![5, 6, 20]);
   }
 
   #[test]
   fn test_majority_insertions() {
     let ins = majority_insertions(&block_2());
-    pretty_assert_eq!(ins, vec![Ins::new(0, "G"), Ins::new(13, "AA"), Ins::new(23, "TT")]);
+    assert_eq!(ins, vec![Ins::new(0, "G"), Ins::new(13, "AA"), Ins::new(23, "TT")]);
   }
 
   #[test]
@@ -335,7 +338,7 @@ mod tests {
     let dels = vec![5, 6, 20];
     let ins = vec![Ins::new(0, "G"), Ins::new(13, "AA"), Ins::new(23, "TT")];
     let cons = apply_indels(consensus, &dels, &ins);
-    pretty_assert_eq!(cons, "GAGGACCGATCTAAATTCGGAAATT");
+    assert_eq!(cons, "GAGGACCGATCTAAATTCGGAAATT");
   }
 
   #[test]
@@ -343,7 +346,7 @@ mod tests {
     let mut block = block_3();
     let expected_block = block_3_reconsensus();
     reconsensus(&mut block).unwrap();
-    pretty_assert_eq!(block.consensus(), expected_block.consensus());
-    pretty_assert_eq!(block.alignments(), expected_block.alignments());
+    assert_eq!(block.consensus(), expected_block.consensus());
+    assert_eq!(block.alignments(), expected_block.alignments());
   }
 }

--- a/packages/pangraph/src/representation/mod.rs
+++ b/packages/pangraph/src/representation/mod.rs
@@ -1,0 +1,2 @@
+pub mod seq;
+pub mod seq_char;

--- a/packages/pangraph/src/representation/seq.rs
+++ b/packages/pangraph/src/representation/seq.rs
@@ -1,0 +1,579 @@
+use crate::representation::seq_char::AsciiChar;
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use std::borrow::Cow;
+
+/// Represents genetic sequence (ASCII characters only)
+#[must_use]
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Default)]
+pub struct Seq {
+  data: Vec<AsciiChar>,
+}
+
+impl Seq {
+  pub fn new() -> Self {
+    Self { data: Vec::new() }
+  }
+
+  pub fn with_capacity(capacity: usize) -> Self {
+    Self {
+      data: Vec::with_capacity(capacity),
+    }
+  }
+
+  pub fn from_elem<T: Into<u8>>(elem: T, n: usize) -> Self {
+    Self {
+      data: vec![AsciiChar::from(elem.into()); n],
+    }
+  }
+
+  pub fn from_str(s: &str) -> Self {
+    debug_assert!(s.is_ascii());
+    Self {
+      data: s.as_bytes().iter().copied().map(AsciiChar::from).collect(),
+    }
+  }
+
+  pub fn from_vec(vec: Vec<u8>) -> Self {
+    Self {
+      data: vec.into_iter().map(AsciiChar::from).collect(),
+    }
+  }
+
+  pub fn from_slice(slice: &[u8]) -> Self {
+    Self {
+      data: slice.iter().copied().map(AsciiChar::from).collect(),
+    }
+  }
+
+  pub fn concat(sequences: &[&Self]) -> Self {
+    let total_len = sequences.iter().map(|s| s.len()).sum();
+    let mut data = Vec::with_capacity(total_len);
+    for seq in sequences {
+      data.extend_from_slice(&seq.data);
+    }
+    Seq { data }
+  }
+
+  pub fn extend_seq(&mut self, other: &Seq) {
+    self.data.extend_from_slice(&other.data);
+  }
+
+  pub fn len(&self) -> usize {
+    self.data.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.data.is_empty()
+  }
+
+  pub fn clear(&mut self) {
+    self.data.clear();
+  }
+
+  pub fn truncate(&mut self, len: usize) {
+    self.data.truncate(len);
+  }
+
+  pub fn push(&mut self, byte: AsciiChar) {
+    self.data.push(byte);
+  }
+
+  pub fn pop(&mut self) -> Option<AsciiChar> {
+    self.data.pop().map(Into::into)
+  }
+
+  pub fn capacity(&self) -> usize {
+    self.data.capacity()
+  }
+
+  pub fn reserve(&mut self, additional: usize) {
+    self.data.reserve(additional);
+  }
+
+  pub fn reserve_exact(&mut self, additional: usize) {
+    self.data.reserve_exact(additional);
+  }
+
+  #[allow(unsafe_code)]
+  pub fn as_str(&self) -> &str {
+    // SAFETY: `self.data.as_ptr()` is guaranteed to be valid for reads and properly aligned
+    // because `data` is a `Vec<AsciiChar>`. The `AsciiChar` type ensures that each element is a valid
+    // single-byte ASCII character, making the conversion to a `u8` pointer valid.
+    let byte_slice = unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast::<u8>(), self.data.len()) };
+
+    // SAFETY: `from_utf8_unchecked` is safe here because `byte_slice` is guaranteed to contain only
+    // valid UTF-8 data. This is ensured by the invariant that `AsciiChar` can only hold valid ASCII characters,
+    // which are a subset of UTF-8.
+    unsafe { std::str::from_utf8_unchecked(byte_slice) }
+  }
+
+  pub fn as_slice(&self) -> &[AsciiChar] {
+    &self.data
+  }
+
+  pub fn as_mut_slice(&mut self) -> &mut [AsciiChar] {
+    &mut self.data
+  }
+
+  pub fn insert(&mut self, index: usize, byte: u8) {
+    self.data.insert(index, AsciiChar::from(byte));
+  }
+
+  pub fn insert_seq(&mut self, index: usize, other: &Seq) {
+    let len = self.len();
+    assert!(
+      index <= len,
+      "Attempted to insert outside of array boundaries: array size is {len}, index is {index}"
+    );
+
+    self.data.reserve(other.data.len());
+    let mut tail = self.data.split_off(index);
+    self.data.extend_from_slice(&other.data);
+    self.data.append(&mut tail);
+  }
+
+  pub fn remove(&mut self, index: usize) -> u8 {
+    self.data.remove(index).into()
+  }
+
+  pub fn append(&mut self, other: &mut Vec<u8>) {
+    self.data.extend(other.drain(..).map(AsciiChar::from));
+  }
+
+  pub fn push_str(&mut self, s: &str) {
+    self.data.extend(s.as_bytes().iter().copied().map(AsciiChar::from));
+  }
+
+  pub fn contains_str(&self, s: &str) -> bool {
+    self.as_str().contains(s)
+  }
+
+  pub fn starts_with(&self, prefix: &str) -> bool {
+    self.as_str().starts_with(prefix)
+  }
+
+  pub fn ends_with(&self, suffix: &str) -> bool {
+    self.as_str().ends_with(suffix)
+  }
+
+  pub fn find(&self, substring: &str) -> Option<usize> {
+    self.as_str().find(substring)
+  }
+
+  pub fn rfind(&self, substring: &str) -> Option<usize> {
+    self.as_str().rfind(substring)
+  }
+
+  pub fn split_off(&mut self, at: usize) -> Seq {
+    Seq {
+      data: self.data.split_off(at),
+    }
+  }
+
+  pub fn retain<F>(&mut self, f: F)
+  where
+    F: FnMut(&AsciiChar) -> bool,
+  {
+    self.data.retain(f);
+  }
+
+  pub fn rotate_left(&mut self, mid: usize) {
+    self.data.rotate_left(mid);
+  }
+
+  pub fn rotate_right(&mut self, mid: usize) {
+    self.data.rotate_right(mid);
+  }
+}
+
+impl PartialEq<str> for Seq {
+  fn eq(&self, other: &str) -> bool {
+    if self.data.len() != other.len() {
+      return false;
+    }
+    self.data.iter().zip(other.as_bytes()).all(|(&AsciiChar(c), &b)| c == b)
+  }
+}
+
+impl PartialEq<String> for Seq {
+  fn eq(&self, other: &String) -> bool {
+    self == other.as_str()
+  }
+}
+
+impl PartialEq<&str> for Seq {
+  fn eq(&self, other: &&str) -> bool {
+    self == *other
+  }
+}
+
+impl PartialEq<Seq> for str {
+  fn eq(&self, other: &Seq) -> bool {
+    other == self
+  }
+}
+
+impl PartialEq<Seq> for String {
+  fn eq(&self, other: &Seq) -> bool {
+    other == self.as_str()
+  }
+}
+
+impl PartialEq<&String> for Seq {
+  fn eq(&self, other: &&String) -> bool {
+    self == other.as_str()
+  }
+}
+
+impl PartialEq<&Seq> for Seq {
+  fn eq(&self, other: &&Seq) -> bool {
+    self == *other
+  }
+}
+
+impl PartialEq<Seq> for &str {
+  fn eq(&self, other: &Seq) -> bool {
+    *self == other
+  }
+}
+
+impl PartialEq<Seq> for &String {
+  fn eq(&self, other: &Seq) -> bool {
+    self.as_str() == other
+  }
+}
+
+impl PartialEq<&Seq> for str {
+  fn eq(&self, other: &&Seq) -> bool {
+    *other == self
+  }
+}
+
+impl PartialEq<&Seq> for String {
+  fn eq(&self, other: &&Seq) -> bool {
+    self.as_str() == *other
+  }
+}
+
+impl PartialEq<[char]> for Seq {
+  fn eq(&self, other: &[char]) -> bool {
+    self.data.len() == other.len() && self.data.iter().zip(other).all(|(&AsciiChar(c), &ch)| c as char == ch)
+  }
+}
+
+impl PartialEq<&[char]> for Seq {
+  fn eq(&self, other: &&[char]) -> bool {
+    self == *other
+  }
+}
+
+impl PartialEq<Vec<char>> for Seq {
+  fn eq(&self, other: &Vec<char>) -> bool {
+    self == other.as_slice()
+  }
+}
+
+impl PartialEq<[u8]> for Seq {
+  fn eq(&self, other: &[u8]) -> bool {
+    self.data.len() == other.len() && self.data.iter().zip(other).all(|(&AsciiChar(c), &b)| c == b)
+  }
+}
+
+impl PartialEq<&[u8]> for Seq {
+  fn eq(&self, other: &&[u8]) -> bool {
+    self == *other
+  }
+}
+
+impl PartialEq<Vec<u8>> for Seq {
+  fn eq(&self, other: &Vec<u8>) -> bool {
+    self == other.as_slice()
+  }
+}
+
+impl PartialEq<[AsciiChar]> for Seq {
+  fn eq(&self, other: &[AsciiChar]) -> bool {
+    self.data == other
+  }
+}
+
+impl PartialEq<&[AsciiChar]> for Seq {
+  fn eq(&self, other: &&[AsciiChar]) -> bool {
+    self == *other
+  }
+}
+
+impl PartialEq<Vec<AsciiChar>> for Seq {
+  fn eq(&self, other: &Vec<AsciiChar>) -> bool {
+    self == other.as_slice()
+  }
+}
+
+impl core::ops::Deref for Seq {
+  type Target = [AsciiChar];
+  fn deref(&self) -> &Self::Target {
+    &self.data
+  }
+}
+
+impl core::ops::DerefMut for Seq {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.data
+  }
+}
+
+impl From<&Seq> for Seq {
+  fn from(s: &Seq) -> Self {
+    s.to_owned()
+  }
+}
+
+impl From<&str> for Seq {
+  fn from(s: &str) -> Self {
+    Self::from_str(s)
+  }
+}
+
+impl From<&[u8]> for Seq {
+  fn from(slice: &[u8]) -> Self {
+    Self::from_slice(slice)
+  }
+}
+
+impl From<&[AsciiChar]> for Seq {
+  fn from(slice: &[AsciiChar]) -> Self {
+    slice.iter().copied().collect()
+  }
+}
+
+impl Extend<u8> for Seq {
+  fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+    self.data.extend(iter.into_iter().map(AsciiChar::from));
+  }
+}
+
+impl Extend<char> for Seq {
+  fn extend<I: IntoIterator<Item = char>>(&mut self, iter: I) {
+    self.data.extend(iter.into_iter().map(AsciiChar::from));
+  }
+}
+
+impl Extend<AsciiChar> for Seq {
+  fn extend<I: IntoIterator<Item = AsciiChar>>(&mut self, iter: I) {
+    self.data.extend(iter);
+  }
+}
+
+impl FromIterator<u8> for Seq {
+  fn from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Self {
+    Self {
+      data: iter.into_iter().map(AsciiChar::from).collect(),
+    }
+  }
+}
+
+impl FromIterator<AsciiChar> for Seq {
+  fn from_iter<I: IntoIterator<Item = AsciiChar>>(iter: I) -> Self {
+    Self {
+      data: Vec::from_iter(iter),
+    }
+  }
+}
+
+impl FromIterator<Seq> for Seq {
+  fn from_iter<I: IntoIterator<Item = Seq>>(iter: I) -> Self {
+    let data = iter.into_iter().flat_map(|seq| seq.data).collect();
+    Self { data }
+  }
+}
+
+impl AsRef<str> for Seq {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}
+
+impl AsRef<Seq> for Seq {
+  fn as_ref(&self) -> &Seq {
+    self
+  }
+}
+
+impl AsRef<[AsciiChar]> for Seq {
+  fn as_ref(&self) -> &[AsciiChar] {
+    &self.data
+  }
+}
+
+impl AsRef<[u8]> for Seq {
+  fn as_ref(&self) -> &[u8] {
+    self.as_str().as_bytes()
+  }
+}
+
+impl core::fmt::Display for Seq {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl core::fmt::Debug for Seq {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    core::fmt::Display::fmt(self, f)
+  }
+}
+
+impl core::ops::Index<usize> for Seq {
+  type Output = AsciiChar;
+
+  fn index(&self, index: usize) -> &Self::Output {
+    &self.data[index]
+  }
+}
+
+impl core::ops::IndexMut<usize> for Seq {
+  fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    &mut self.data[index]
+  }
+}
+
+impl core::ops::Index<core::ops::Range<usize>> for Seq {
+  type Output = [AsciiChar];
+
+  fn index(&self, index: core::ops::Range<usize>) -> &Self::Output {
+    &self.data[index]
+  }
+}
+
+impl core::ops::IndexMut<core::ops::Range<usize>> for Seq {
+  fn index_mut(&mut self, index: core::ops::Range<usize>) -> &mut Self::Output {
+    &mut self.data[index]
+  }
+}
+
+impl std::ops::Add for Seq {
+  type Output = Self;
+
+  fn add(mut self, other: Self) -> Self::Output {
+    self.data.extend(other.data);
+    self
+  }
+}
+
+impl std::ops::Mul<usize> for Seq {
+  type Output = Self;
+
+  fn mul(mut self, rhs: usize) -> Self::Output {
+    let original = self.data.clone();
+    for _ in 1..rhs {
+      self.data.extend(&original);
+    }
+    self
+  }
+}
+
+impl<'a> IntoIterator for &'a Seq {
+  type Item = &'a AsciiChar;
+  type IntoIter = core::slice::Iter<'a, AsciiChar>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.data.iter()
+  }
+}
+
+impl<'a> IntoIterator for &'a mut Seq {
+  type Item = &'a mut AsciiChar;
+  type IntoIter = core::slice::IterMut<'a, AsciiChar>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.data.iter_mut()
+  }
+}
+
+impl IntoIterator for Seq {
+  type Item = AsciiChar;
+  type IntoIter = std::vec::IntoIter<AsciiChar>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.data.into_iter()
+  }
+}
+
+#[allow(unsafe_code)]
+impl std::io::Read for Seq {
+  fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    let len = std::cmp::min(buf.len(), self.len());
+    // SAFETY:
+    // 1. `self.data` is guaranteed to hold only ASCII characters because `Seq` enforces this invariant via `AsciiChar`.
+    // 2. The length `len` is calculated as the minimum of `buf.len()` and `self.len()`, ensuring no out-of-bounds access for either slice.
+    // 3. `std::ptr::copy_nonoverlapping` is safe to use here because:
+    //    a. Both `self.data` and `buf` are valid, properly aligned, and non-overlapping.
+    //    b. The memory regions are guaranteed to be accessible for `len` bytes.
+    unsafe {
+      std::ptr::copy_nonoverlapping(self.data.as_ptr().cast::<u8>(), buf.as_mut_ptr(), len);
+    }
+    self.data.drain(..len);
+    Ok(len)
+  }
+}
+
+impl std::io::Write for Seq {
+  fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    self.extend(buf.iter().copied());
+    Ok(buf.len())
+  }
+
+  fn flush(&mut self) -> std::io::Result<()> {
+    Ok(())
+  }
+}
+
+impl serde::Serialize for Seq {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer
+      .serialize_str(self.as_str())
+      .map_err(serde::ser::Error::custom)
+  }
+}
+
+impl<'de> serde::Deserialize<'de> for Seq {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s = String::deserialize(deserializer)?;
+    Ok(Seq::from_str(&s))
+  }
+}
+
+impl JsonSchema for Seq {
+  fn always_inline_schema() -> bool {
+    true
+  }
+
+  fn schema_name() -> Cow<'static, str> {
+    Cow::from("Seq")
+  }
+
+  fn json_schema(g: &mut SchemaGenerator) -> Schema {
+    g.subschema_for::<String>()
+  }
+}
+
+#[macro_export]
+macro_rules! seq {
+  () => (
+      $crate::representation::seq::Seq::new()
+  );
+  ($elem:expr; $n:expr) => (
+      $crate::representation::seq::Seq::from_elem($elem, $n)
+  );
+  ($($char:expr),* $(,)?) => {
+    {
+      $crate::representation::seq::Seq::from_iter([$($char),*].map(|c| c as u8).into_iter())
+    }
+  };
+}

--- a/packages/pangraph/src/representation/seq_char.rs
+++ b/packages/pangraph/src/representation/seq_char.rs
@@ -1,0 +1,141 @@
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use std::borrow::Cow;
+use std::fmt::Write as StdFmtWrite;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AsciiChar(pub u8);
+
+impl AsciiChar {
+  pub const fn new(value: u8) -> Self {
+    Self(value)
+  }
+
+  pub const fn inner(&self) -> u8 {
+    self.0
+  }
+
+  pub fn from_str(s: &str) -> Self {
+    debug_assert!(s.is_ascii());
+    debug_assert!(s.len() == 1);
+    Self(s.as_bytes()[0])
+  }
+}
+
+impl core::fmt::Display for AsciiChar {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_char(self.0 as char)
+  }
+}
+
+impl core::fmt::Debug for AsciiChar {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    core::fmt::Display::fmt(self, f)
+  }
+}
+
+impl From<u8> for AsciiChar {
+  fn from(item: u8) -> Self {
+    AsciiChar(item)
+  }
+}
+
+impl From<u16> for AsciiChar {
+  fn from(item: u16) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<u32> for AsciiChar {
+  fn from(item: u32) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<u64> for AsciiChar {
+  fn from(item: u64) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<usize> for AsciiChar {
+  fn from(item: usize) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<char> for AsciiChar {
+  fn from(item: char) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<AsciiChar> for u8 {
+  fn from(item: AsciiChar) -> Self {
+    item.0
+  }
+}
+
+impl From<AsciiChar> for u16 {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as u16
+  }
+}
+
+impl From<AsciiChar> for u32 {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as u32
+  }
+}
+
+impl From<AsciiChar> for u64 {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as u64
+  }
+}
+
+impl From<AsciiChar> for usize {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as usize
+  }
+}
+
+impl From<AsciiChar> for char {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as char
+  }
+}
+
+impl serde::Serialize for AsciiChar {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    serializer
+      .serialize_str(&self.to_string())
+      .map_err(serde::ser::Error::custom)
+  }
+}
+
+impl<'de> serde::Deserialize<'de> for AsciiChar {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s = String::deserialize(deserializer)?;
+    Ok(AsciiChar::from_str(&s))
+  }
+}
+
+impl JsonSchema for AsciiChar {
+  fn always_inline_schema() -> bool {
+    true
+  }
+
+  fn schema_name() -> Cow<'static, str> {
+    Cow::from("AsciiChar")
+  }
+
+  fn json_schema(g: &mut SchemaGenerator) -> Schema {
+    g.subschema_for::<char>()
+  }
+}

--- a/packages/pangraph/src/utils/collections.rs
+++ b/packages/pangraph/src/utils/collections.rs
@@ -28,56 +28,7 @@ pub fn remove_exactly_one<T>(mut elems: Vec<T>) -> Result<T, Report> {
   }
 }
 
-/// Insert slice into vec at an index
-/// Taken from: https://internals.rust-lang.org/t/add-vec-insert-slice-at-to-insert-the-content-of-a-slice-at-an-arbitrary-index/11008
-pub fn insert_at_inplace<T: Clone>(vec: &mut Vec<T>, index: usize, slice: &[T]) {
-  let len = vec.len();
-  assert!(
-    index <= len,
-    "Attempted to insert outside of array boundaries: array size is {len}, index is {index}"
-  );
-  vec.reserve(slice.len());
-  let mut v = vec.split_off(index);
-  vec.extend_from_slice(slice);
-  vec.append(&mut v);
-}
-
 pub fn has_duplicates<T: Eq + Hash, I: IntoIterator<Item = T>>(iter: I) -> bool {
   let mut seen = HashSet::new();
   iter.into_iter().any(|item| !seen.insert(item))
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  use pretty_assertions::assert_eq;
-  use rstest::rstest;
-
-  #[rstest]
-  fn test_insert_at_inplace_general_case() {
-    let mut vec = vec![1; 6];
-    let slice = [0; 2];
-    let index = 2;
-    insert_at_inplace(&mut vec, index, &slice);
-    assert_eq!(vec![1, 1, 0, 0, 1, 1, 1, 1], vec);
-  }
-
-  #[rstest]
-  fn test_insert_at_inplace_append() {
-    let mut vec = vec![1; 6];
-    let slice = [0; 2];
-    let index = 6;
-    insert_at_inplace(&mut vec, index, &slice);
-    assert_eq!(vec![1, 1, 1, 1, 1, 1, 0, 0], vec);
-  }
-
-  #[rstest]
-  fn test_insert_at_inplace_prepend() {
-    let mut vec = vec![1; 6];
-    let slice = [0; 2];
-    let index = 0;
-    insert_at_inplace(&mut vec, index, &slice);
-    assert_eq!(vec![0, 0, 1, 1, 1, 1, 1, 1], vec);
-  }
 }


### PR DESCRIPTION
This introduces `AsciiChar` and `Seq` classes which represent an ASCII-character and ASCII-string. It's a `u8` and a `Vec` underneath, so it combines useful methods which are string-like and array-like for our application.

The main idea is that because Rust `String` are unicode and `char` are 32-bit integers, it's wasteful and slow to use that to represent genetic sequences. We should do better with `u8` 8-bit charters and with ASCII set assumption, e.g. no more unnecessary code splitting preservation, and we can afford more flexible and more efficient methods.

In reality, compared to the same transition in treetime project, where we observed 2x speedup, this did not introduce any significant speedup in my measurements in pangraph. However, memory occupied by sequences should reduce by a factor of 4.

Both of the new classes could use some more unit tests.