### PR TITLE
feat: make error message in mmseqs check prettier

### DIFF
--- a/packages/pangraph/src/commands/build/build_run.rs
+++ b/packages/pangraph/src/commands/build/build_run.rs
@@ -8,6 +8,8 @@ use crate::pangraph::strand::Strand::Forward;
 use crate::tree::clade::postorder;
 use crate::tree::neighbor_joining::build_tree_using_neighbor_joining;
 use crate::{make_internal_error, make_internal_report};
+use color_eyre::owo_colors::{AnsiColors, OwoColorize};
+use color_eyre::{Help, SectionExt};
 use eyre::{Report, WrapErr};
 use itertools::Itertools;
 use log::info;
@@ -19,12 +21,12 @@ pub fn build_cmd_preliminary_checks(args: &PangraphBuildArgs) -> Result<(), Repo
     std::process::Command::new("mmseqs")
       .arg("--help")
       .output()
-      .map_err(|err| {
-        eyre::eyre!(
-          "Executing `mmseqs --help` results in the following error:\n{}\nPlease make sure that `mmseqs` is installed and available in PATH.",
-          err
-        )
-      })?;
+      .wrap_err("When executing `mmseqs --help`")
+      .section(
+        "Please make sure that `mmseqs` is installed, available in PATH and is functional outside of pangraph. For more details, refer to mmseqs documentation at https://github.com/soedinglab/MMseqs2"
+          .color(AnsiColors::Cyan)
+          .header("Suggestion:"),
+      )?;
   }
 
   Ok(())


### PR DESCRIPTION
This follows `color_eyre` conventions and uses different sections to make error message prettier.

It's important to note that any error can manifest with this exact message (e.g. if mmseqs requires libraries and they are missing, or if mmseqs binary is not executable, if it segfaults etc.), so I made the suggestion message a little more generic (not assuming that the error is "file not found").

![Image](https://github.com/user-attachments/assets/346bf3f9-db27-4c7f-a2d1-cd642c0d008f)