### PR TITLE
feat: make error message in mmseqs run prettier

### DIFF
--- a/packages/pangraph/src/pangraph/graph_merging.rs
+++ b/packages/pangraph/src/pangraph/graph_merging.rs
@@ -176,6 +176,7 @@ pub fn find_matches(
     AlignmentBackend::Minimap2 => align_with_minimap2_lib(blocks, &args.aln_args),
     AlignmentBackend::Mmseqs => align_with_mmseqs(blocks, &args.aln_args),
   }
+  .wrap_err_with(|| format!("When trying to align sequences using {}", &args.alignment_kernel))
 }
 
 pub fn filter_matches(alns: &[Alignment], args: &AlignmentArgs) -> Vec<Alignment> {

--- a/packages/pangraph/src/utils/subprocess.rs
+++ b/packages/pangraph/src/utils/subprocess.rs
@@ -64,6 +64,6 @@ where
 pub fn create_arg_optional(name: impl AsRef<str>, value: &Option<impl ToString>) -> Vec<String> {
   value
     .as_ref()
-    .map(|kmer_len| vec![name.as_ref().to_owned(), kmer_len.to_string()])
+    .map(|value| vec![name.as_ref().to_owned(), value.to_string()])
     .unwrap_or_default()
 }


### PR DESCRIPTION
This follows `color_eyre` conventions and uses different sections to make error message prettier.

I think that chaining `.arg()` and then adding `-k` with `.args()` does not necessarily actually adds `-k`, but I don't know how to check it. So I opted for manually constructing all-in-one array of args, which I pass using a single `.args()` call. This also allow us to print the full command to the user and inspect it during debugging.

Also refactored and simplified things a little.

![Image](https://github.com/user-attachments/assets/726a580f-c7f2-4e59-8f45-50089ab8125e)