### PR TITLE
fix: handle --strains arg values and positional args in simplify command

### DIFF
--- a/packages/pangraph/src/commands/simplify/simplify_args.rs
+++ b/packages/pangraph/src/commands/simplify/simplify_args.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use std::fmt::Debug;
 use std::path::PathBuf;
 
@@ -21,6 +21,7 @@ pub struct PangraphSimplifyArgs {
   pub output: PathBuf,
 
   /// Isolates to project onto: collapse the graph to only blocks contained by paths of the given isolates. List of strain names, comma-delimited without spaces.
-  #[clap(long, short = 's', num_args=1.., use_value_delimiter = true)]
+  #[clap(long, short = 's', required = true, num_args = 1, action = ArgAction::Set, value_delimiter=',')]
+  // See: https://github.com/clap-rs/clap/issues/4942#issuecomment-1565139247
   pub strains: Vec<String>,
 }


### PR DESCRIPTION
When running
```
pangraph simplify --strains NZ_CP013711,NC_017540 input.json
```
clap would include `input.json` into the `strains` vec, that is, the positional argument is treated as a continuation of the list of strains. In this case pangraph find no positional args and tries to read input from stdin, even though we clearly passed a positional argument. This is surprising behavior from clap.

Setting `value_delimiter=','` alone did not help. I found that this magic helps: https://github.com/clap-rs/clap/issues/4942#issuecomment-1565139247 however I have no understanding what happens here.

Another problem is that if user writes wrong things like:
```
pangraph simplify --strains input.json
```
or
```
pangraph simplify --strains ${strains} input.json
```
and `${strains}` shell variable happens to be empty (due to a user mistake), the program again includes `input.json` into strains, then finds no positional args and tries to read from stdin. This is confusing and not very helpful behavior. I don't currently have a solution for this.