### PR TITLE
feat: hint possible missing option value when reading from tty

### DIFF
--- a/packages/pangraph/src/io/file.rs
+++ b/packages/pangraph/src/io/file.rs
@@ -13,13 +13,21 @@ pub const DEFAULT_FILE_BUF_SIZE: usize = 256 * 1024;
 
 const TTY_WARNING: &str = "Reading from standard input which is a TTY (e.g. an interactive terminal). This is likely not what you meant. Instead:
 
- - if you want to read fasta from the output of another program, try:
+ - if you want to read the input data from the output of another program, try:
 
     cat /path/to/file | pangraph <your other flags>
 
  - if you want to read from file(s), don't forget to provide a path:
 
     pangraph /path/to/file
+
+ - make sure you handle options and positional arguments correctly: if an option requires a value and you don't provide it, the positional argument following the option could be incorrectly treated as the options' value, due to ambiguity in parsing:
+
+    pangraph --option <forgot_the_value_here> positional_arg
+
+   Also, consider using `--option=value` syntax as well as end-of-options delimiter (`--`) to disambiguate:
+
+    pangraph --option=value -- positional_arg
 ";
 
 /// Open stdin


### PR DESCRIPTION
Followup of: https://github.com/neherlab/pangraph/pull/120

When user forgets to pass a value for an option and pangraph treats the next positional argument as options' value instead, and all happens in a TTY, we can emit a useful hint. This PR adds this hint.

The normal invocation is:
```
pangraph simplify --strains NZ_CP013711,NC_017540 input.json
```

If user writes wrong things like:
```
pangraph simplify --strains input.json
```
or
```
pangraph simplify --strains ${strains} input.json
```
and `${strains}` shell variable happens to be empty (due to a user mistake).

The program again includes `input.json` into `strains`, then finds no positional args and tries to read from stdin.

If stdin happens to be a TTY, i.e. user types this command in a console, then this new message will give them some information on how to fix the problem.