### PR TITLE
feat: downgrade noisy log calls from info to debug level

### DIFF
--- a/packages/pangraph/src/align/nextclade/align/align.rs
+++ b/packages/pangraph/src/align/nextclade/align/align.rs
@@ -11,7 +11,7 @@ use crate::align::nextclade::alphabet::letter::Letter;
 use crate::align::nextclade::alphabet::nuc::Nuc;
 use crate::make_error;
 use eyre::{Report, WrapErr};
-use log::{info, trace, warn};
+use log::{debug, trace, warn};
 use std::cmp::max;
 
 fn align_pairwise<T: Letter<T>>(
@@ -53,7 +53,7 @@ pub fn align_nuc_simplestripe(
   let mut alignment = align_pairwise(qry_seq, ref_seq, gap_open_close, params, &stripes);
 
   while alignment.hit_boundary && attempt < params.max_alignment_attempts {
-    info!("In nucleotide alignment: Band boundary is hit on attempt {}. Retrying with relaxed parameters. Alignment score was: {}", attempt+1, alignment.alignment_score);
+    debug!("In nucleotide alignment: Band boundary is hit on attempt {}. Retrying with relaxed parameters. Alignment score was: {}", attempt+1, alignment.alignment_score);
     // double bandwidth parameters or increase to one if 0
     band_width = max(2 * band_width, 1);
     stripes = simple_stripes(mean_shift, band_width, ref_len, qry_len);
@@ -66,7 +66,7 @@ pub fn align_nuc_simplestripe(
   if alignment.hit_boundary {
     warn!("In nucleotide alignment: Attempted to relax band parameters {attempt} times, but still hitting the band boundary. Returning last attempt with score: {}", alignment.alignment_score);
   } else if attempt > 0 {
-    info!(
+    debug!(
       "In nucleotide alignment: Succeeded without hitting band boundary on attempt {}. Alignment score was: {}",
       attempt + 1,
       alignment.alignment_score
@@ -134,7 +134,7 @@ pub fn align_nuc(
   let mut alignment = align_pairwise(&qry_seq, ref_seq, gap_open_close, params, &stripes);
 
   while alignment.hit_boundary && attempt < params.max_alignment_attempts {
-    info!("When processing sequence #{index} '{seq_name}': In nucleotide alignment: Band boundary is hit on attempt {}. Retrying with relaxed parameters. Alignment score was: {}", attempt+1, alignment.alignment_score);
+    debug!("When processing sequence #{index} '{seq_name}': In nucleotide alignment: Band boundary is hit on attempt {}. Retrying with relaxed parameters. Alignment score was: {}", attempt+1, alignment.alignment_score);
     // double bandwidth parameters or increase to one if 0
     terminal_bandwidth = max(2 * terminal_bandwidth, 1);
     excess_bandwidth = max(2 * excess_bandwidth, 1);
@@ -158,14 +158,14 @@ pub fn align_nuc(
   }
   // report success/failure of broadening of band width
   if alignment.hit_boundary {
-    info!("When processing sequence #{index} '{seq_name}': In nucleotide alignment: Attempted to relax band parameters {attempt} times, but still hitting the band boundary. Returning last attempt with score: {}", alignment.alignment_score);
+    debug!("When processing sequence #{index} '{seq_name}': In nucleotide alignment: Attempted to relax band parameters {attempt} times, but still hitting the band boundary. Returning last attempt with score: {}", alignment.alignment_score);
     if band_area > max_band_area {
-      info!(
+      debug!(
         "When processing sequence #{index} '{seq_name}': final band area {band_area} exceeded the cutoff {max_band_area}"
       );
     }
   } else if attempt > 0 {
-    info!("When processing sequence #{index} '{seq_name}': In nucleotide alignment: Succeeded without hitting band boundary on attempt {}. Alignment score was: {}", attempt+1, alignment.alignment_score);
+    debug!("When processing sequence #{index} '{seq_name}': In nucleotide alignment: Succeeded without hitting band boundary on attempt {}. Alignment score was: {}", attempt+1, alignment.alignment_score);
   }
   alignment.is_reverse_complement = is_reverse_complement;
   Ok(Some(alignment))

--- a/packages/pangraph/src/circularize/circularize.rs
+++ b/packages/pangraph/src/circularize/circularize.rs
@@ -4,13 +4,13 @@ use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::pangraph_block::BlockId;
 use crate::pangraph::pangraph_path::PathId;
 use eyre::Report;
-use log::info;
+use log::debug;
 use std::collections::{BTreeMap, HashMap};
 
 /// Removes transitive edges from the graph inplace.
 pub fn remove_transitive_edges(graph: &mut Pangraph) -> Result<(), Report> {
   while let Some(edge) = find_transitive_edges(graph).first() {
-    info!(
+    debug!(
       "--- Merging transitive edge between blocks {:?} and {:?}",
       edge.n1.bid, edge.n2.bid
     );


### PR DESCRIPTION
Resolves #137

This aims to reduce clutter in info-level log.

Downgraded are:
 - all messages in alignment package
 - the "Merging transitive edge" message