### PR TITLE
chore(ci): upgrade windows runner from windows-2019 to windows-2022

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -337,7 +337,7 @@ jobs:
   run-compat-tests-x86_64-pc-windows-gnu:
     name: "Compat test (x86_64-pc-windows-gnu)"
     needs: [ build-cli ]
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - name: "Show system info"


### PR DESCRIPTION
CI failed due to scheduled brownout of windows-2019 runner. Let's upgrade to the next most recent, windows-2022.

We don't want to upgrade to the latest, because the whole point of compat testing is to be compatible with as many devices as possible.

Error log:
```
Compat test (x86_64-pc-windows-gnu)
This is a scheduled Windows Server 2019 brownout. The Windows Server 2019 image will be removed on 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
```

Example failing run:
https://github.com/neherlab/pangraph/actions/runs/15562122861/job/43818075493?pr=148