### PR TITLE
Feat/bypass guidetree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- added `--guide-tree` option to `pangraph build` command to allow users to provide a custom guide tree in Newick format, see #180.
+
 ## 1.2.2
 
 - improved FASTA input file parsing and error messages for invalid characters, see #173.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - added `--guide-tree` option to `pangraph build` command to allow users to provide a custom guide tree in Newick format, see #180.
+- in `--verbose` logging mode, the guide tree is now printed in Newick format.
 
 ## 1.2.2
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -135,6 +135,9 @@ Align genomes into a multiple sequence alignment graph
 * `--max-alignment-attempts <MAX_ALIGNMENT_ATTEMPTS>` — For within-block alignment: number of times Nextclade will retry alignment with more relaxed results if alignment band boundaries are hit
 
   Default value: `4`
+* `--guide-tree <GUIDE_TREE>` — Path to a Newick-format guide tree to use instead of the default neighbor-joining tree.
+
+   When provided, the tree's topology drives the bottom-up graph-merging order. Each input FASTA sequence must appear exactly once as a leaf (matched by sequence name), and every internal node must be strictly bifurcating. Branch lengths and internal labels, if present, are ignored. Accepts plain or compressed files (gz, bz2, xz, zst).
 
 
 

--- a/packages/pangraph/src/commands/build/build_args.rs
+++ b/packages/pangraph/src/commands/build/build_args.rs
@@ -83,4 +83,13 @@ pub struct PangraphBuildArgs {
   #[clap(long, default_value_t = PangraphBuildArgs::default().max_alignment_attempts)]
   #[clap(value_hint = ValueHint::Other)]
   pub max_alignment_attempts: usize,
+
+  /// Path to a Newick-format guide tree to use instead of the default neighbor-joining tree.
+  ///
+  /// When provided, the tree's topology drives the bottom-up graph-merging order. Each input
+  /// FASTA sequence must appear exactly once as a leaf (matched by sequence name), and every
+  /// internal node must be strictly bifurcating. Branch lengths and internal labels, if present,
+  /// are ignored. Accepts plain or compressed files (gz, bz2, xz, zst).
+  #[clap(long, value_hint = ValueHint::FilePath)]
+  pub guide_tree: Option<PathBuf>,
 }

--- a/packages/pangraph/src/commands/build/build_run.rs
+++ b/packages/pangraph/src/commands/build/build_run.rs
@@ -7,6 +7,7 @@ use crate::pangraph::pangraph::Pangraph;
 use crate::pangraph::strand::Strand::Forward;
 use crate::tree::clade::postorder;
 use crate::tree::neighbor_joining::build_tree_using_neighbor_joining;
+use crate::tree::newick::build_tree_from_newick;
 use crate::utils::progress_bar::ProgressBar;
 use crate::{make_internal_error, make_internal_report};
 use color_eyre::owo_colors::{AnsiColors, OwoColorize};
@@ -92,8 +93,12 @@ pub fn build(fastas: Vec<FastaRecord>, args: &PangraphBuildArgs, verify: bool) -
     .map(|fasta| Pangraph::singleton(fasta, Forward, args.circular)) // FIXME: strand hardcoded
     .collect_vec();
 
-  // Build guide tree
-  let tree = build_tree_using_neighbor_joining(graphs)?;
+  // Build guide tree, or load it from a user-supplied Newick file.
+  let tree = match &args.guide_tree {
+    Some(path) => build_tree_from_newick(path, graphs)
+      .wrap_err_with(|| format!("When loading guide tree from '{}'", path.display()))?,
+    None => build_tree_using_neighbor_joining(graphs)?,
+  };
 
   // Instantiate the progress bar
   let pb = ProgressBar::new(n_paths - 1, args.no_progress_bar)?;

--- a/packages/pangraph/src/commands/build/build_run.rs
+++ b/packages/pangraph/src/commands/build/build_run.rs
@@ -100,6 +100,9 @@ pub fn build(fastas: Vec<FastaRecord>, args: &PangraphBuildArgs, verify: bool) -
     None => build_tree_using_neighbor_joining(graphs)?,
   };
 
+  // Log the guide tree topology in Newick format (visible at `info` log level and above).
+  info!("Guide tree (newick): {}", tree.read().to_newick());
+
   // Instantiate the progress bar
   let pb = ProgressBar::new(n_paths - 1, args.no_progress_bar)?;
 

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -8,6 +8,7 @@ use crate::pangraph::pangraph_node::{NodeId, PangraphNode};
 use crate::pangraph::pangraph_path::{PangraphPath, PathId};
 use crate::pangraph::strand::Strand;
 use crate::representation::seq::Seq;
+use crate::tree::clade::WithNewickName;
 use crate::utils::map_merge::{ConflictResolution, map_merge};
 use eyre::{Report, WrapErr};
 use maplit::btreemap;
@@ -273,6 +274,22 @@ impl FromStr for Pangraph {
   }
 }
 
+impl WithNewickName for Pangraph {
+  /// Returns a Newick-safe label for this graph: the path name for a singleton,
+  /// or names joined with `|` for a multi-path graph. `None` if no paths are named.
+  fn newick_name(&self) -> Option<String> {
+    let names: Vec<&str> = self.paths.values().filter_map(|p| p.name.as_deref()).collect();
+    (!names.is_empty()).then(|| names.join("|"))
+  }
+}
+
+impl WithNewickName for Option<Pangraph> {
+  /// Internal tree nodes carry `None` (unlabeled in Newick); leaves delegate to `Pangraph`.
+  fn newick_name(&self) -> Option<String> {
+    self.as_ref().and_then(WithNewickName::newick_name)
+  }
+}
+
 #[derive(Debug)]
 pub struct GraphUpdate {
   pub b_old_id: BlockId,
@@ -388,5 +405,66 @@ mod tests {
       NodeId(14) => new_nodes[&NodeId(14)].clone(),
     };
     assert_eq!(G.nodes, expected_nodes);
+  }
+
+  /// Builds a `Pangraph` whose only relevant content for `newick_name` is its `paths` map.
+  /// Blocks and nodes are left empty since `newick_name` only inspects path names.
+  fn pangraph_with_named_paths(names: &[Option<&str>]) -> Pangraph {
+    let paths = names
+      .iter()
+      .enumerate()
+      .map(|(i, name)| {
+        let path = PangraphPath::new(
+          Some(PathId(i)),
+          Vec::<NodeId>::new(),
+          0,
+          false,
+          name.map(String::from),
+          None,
+        );
+        (path.id, path)
+      })
+      .collect::<BTreeMap<_, _>>();
+    Pangraph {
+      paths,
+      blocks: BTreeMap::new(),
+      nodes: BTreeMap::new(),
+    }
+  }
+
+  #[test]
+  fn test_newick_name_singleton_named() {
+    let g = pangraph_with_named_paths(&[Some("isolate_A")]);
+    assert_eq!(g.newick_name(), Some("isolate_A".to_owned()));
+  }
+
+  #[test]
+  fn test_newick_name_singleton_unnamed() {
+    let g = pangraph_with_named_paths(&[None]);
+    assert_eq!(g.newick_name(), None);
+  }
+
+  #[test]
+  fn test_newick_name_multi_path_all_named() {
+    let g = pangraph_with_named_paths(&[Some("a"), Some("b"), Some("c")]);
+    assert_eq!(g.newick_name(), Some("a|b|c".to_owned()));
+  }
+
+  #[test]
+  fn test_newick_name_multi_path_some_unnamed() {
+    let g = pangraph_with_named_paths(&[Some("a"), None, Some("c")]);
+    assert_eq!(g.newick_name(), Some("a|c".to_owned()));
+  }
+
+  #[test]
+  fn test_newick_name_option_pangraph_none() {
+    let g: Option<Pangraph> = None;
+    assert_eq!(g.newick_name(), None);
+  }
+
+  #[test]
+  fn test_newick_name_option_pangraph_some() {
+    let g = Some(pangraph_with_named_paths(&[Some("only")]));
+    assert_eq!(g.newick_name(), Some("only".to_owned()));
   }
 }

--- a/packages/pangraph/src/pangraph/pangraph.rs
+++ b/packages/pangraph/src/pangraph/pangraph.rs
@@ -308,6 +308,7 @@ mod tests {
   use crate::pangraph::pangraph_path::PangraphPath;
   use crate::pangraph::strand::Strand::{Forward, Reverse};
   use maplit::btreemap;
+  use rstest::rstest;
 
   #[test]
   fn test_graph_update() {
@@ -433,38 +434,18 @@ mod tests {
   }
 
   #[test]
-  fn test_newick_name_singleton_named() {
-    let g = pangraph_with_named_paths(&[Some("isolate_A")]);
-    assert_eq!(g.newick_name(), Some("isolate_A".to_owned()));
-  }
-
-  #[test]
-  fn test_newick_name_singleton_unnamed() {
-    let g = pangraph_with_named_paths(&[None]);
-    assert_eq!(g.newick_name(), None);
-  }
-
-  #[test]
-  fn test_newick_name_multi_path_all_named() {
-    let g = pangraph_with_named_paths(&[Some("a"), Some("b"), Some("c")]);
-    assert_eq!(g.newick_name(), Some("a|b|c".to_owned()));
-  }
-
-  #[test]
-  fn test_newick_name_multi_path_some_unnamed() {
-    let g = pangraph_with_named_paths(&[Some("a"), None, Some("c")]);
-    assert_eq!(g.newick_name(), Some("a|c".to_owned()));
-  }
-
-  #[test]
-  fn test_newick_name_option_pangraph_none() {
+  fn test_newick_no_graph() {
     let g: Option<Pangraph> = None;
     assert_eq!(g.newick_name(), None);
   }
 
-  #[test]
-  fn test_newick_name_option_pangraph_some() {
-    let g = Some(pangraph_with_named_paths(&[Some("only")]));
-    assert_eq!(g.newick_name(), Some("only".to_owned()));
+  #[rstest]
+  #[case::singleton_named(&[Some("isolate_A")], Some("isolate_A".to_owned()))]
+  #[case::singleton_unnamed(&[None], None)]
+  #[case::multi_path_all_named(&[Some("a"), Some("b"), Some("c")], Some("a|b|c".to_owned()))]
+  #[case::multi_path_some_unnamed(&[Some("a"), None, Some("c")], Some("a|c".to_owned()))]
+  fn test_newick_name(#[case] names: &[Option<&str>], #[case] expected: Option<String>) {
+    let g = pangraph_with_named_paths(names);
+    assert_eq!(g.newick_name(), expected);
   }
 }

--- a/packages/pangraph/src/pangraph/pangraph_block.rs
+++ b/packages/pangraph/src/pangraph/pangraph_block.rs
@@ -86,7 +86,6 @@ impl PangraphBlock {
     self.consensus.len()
   }
 
-
   pub fn unaligned_len_for_edit(&self, edits: &Edit) -> usize {
     let total_dels: usize = edits.dels.iter().map(|del| del.len).sum();
     let total_inss: usize = edits.inss.iter().map(|ins| ins.seq.len()).sum();
@@ -827,5 +826,4 @@ mod tests {
 
     assert_eq!(result_block, expected_block);
   }
-
 }

--- a/packages/pangraph/src/pangraph/reweave.rs
+++ b/packages/pangraph/src/pangraph/reweave.rs
@@ -476,9 +476,9 @@ mod tests {
   use crate::utils::random::get_random_number_generator;
   use maplit::{btreemap, btreeset};
   use noodles::sam::record::Cigar;
-  use rstest::rstest;
   use noodles::sam::record::cigar::op::{Kind, Op};
   use pretty_assertions::assert_eq;
+  use rstest::rstest;
 
   #[test]
   fn test_extract_hits() {

--- a/packages/pangraph/src/tree/balance.rs
+++ b/packages/pangraph/src/tree/balance.rs
@@ -41,7 +41,7 @@ fn leaves<T>(root: &Lock<Clade<T>>) -> Vec<Lock<Clade<T>>> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::tree::clade::WithName;
+  use crate::tree::clade::WithNewickName;
   use eyre::Report;
   use pretty_assertions::assert_eq;
   use rstest::rstest;
@@ -55,9 +55,9 @@ mod tests {
     }
   }
 
-  impl WithName for N {
-    fn name(&self) -> Option<&str> {
-      Some(&self.0)
+  impl WithNewickName for N {
+    fn newick_name(&self) -> Option<String> {
+      Some(self.0.clone())
     }
   }
 

--- a/packages/pangraph/src/tree/clade.rs
+++ b/packages/pangraph/src/tree/clade.rs
@@ -40,8 +40,10 @@ impl<T> Clade<T> {
   }
 }
 
-pub trait WithName {
-  fn name(&self) -> Option<&str>;
+/// Provides a Newick-compatible label for a tree node's payload.
+/// Returning `None` yields an unlabeled node in the Newick output.
+pub trait WithNewickName {
+  fn newick_name(&self) -> Option<String>;
 }
 
 pub fn postorder<T, D, E, F>(clade: &Lock<Clade<D>>, f: F) -> Result<Vec<T>, E>
@@ -86,9 +88,9 @@ mod tests {
     }
   }
 
-  impl WithName for N {
-    fn name(&self) -> Option<&str> {
-      Some(&self.0)
+  impl WithNewickName for N {
+    fn newick_name(&self) -> Option<String> {
+      Some(self.0.clone())
     }
   }
 

--- a/packages/pangraph/src/tree/clade.rs
+++ b/packages/pangraph/src/tree/clade.rs
@@ -44,33 +44,6 @@ pub trait WithName {
   fn name(&self) -> Option<&str>;
 }
 
-impl<T: WithName> Clade<T> {
-  pub fn to_newick(&self) -> String {
-    fn recurse<T: WithName>(clade: &Clade<T>) -> String {
-      if clade.is_leaf() {
-        String::from(clade.data.name().unwrap_or_default())
-      } else {
-        let mut newick = String::from("(");
-        if let Some(left) = &clade.left {
-          newick.push_str(&recurse(&left.read()));
-        }
-        newick.push(',');
-        if let Some(right) = &clade.right {
-          newick.push_str(&recurse(&right.read()));
-        }
-        newick.push(')');
-        if let Some(name) = clade.data.name() {
-          newick.push_str(name);
-        }
-        newick
-      }
-    }
-
-    let newick = recurse(self);
-    format!("{newick};")
-  }
-}
-
 pub fn postorder<T, D, E, F>(clade: &Lock<Clade<D>>, f: F) -> Result<Vec<T>, E>
 where
   F: Fn(&mut Clade<D>) -> Result<T, E>,

--- a/packages/pangraph/src/tree/mod.rs
+++ b/packages/pangraph/src/tree/mod.rs
@@ -1,3 +1,4 @@
 pub mod balance;
 pub mod clade;
 pub mod neighbor_joining;
+pub mod newick;

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -272,6 +272,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::assert_error;
   use crate::io::fasta::FastaRecord;
   use crate::pangraph::strand::Strand::Forward;
   use crate::representation::seq::Seq;
@@ -304,18 +305,20 @@ mod tests {
     assert_eq!(expected, round_trip(input));
   }
 
+  #[rustfmt::skip]
   #[rstest]
-  #[case::empty("")]
-  #[case::only_whitespace("   \n  ")]
-  #[case::unbalanced_open("((A,B);")]
-  #[case::unbalanced_close("A,B);")]
-  #[case::multifurcation("(A,B,C);")]
-  #[case::unifurcation("(A);")]
-  #[case::leaf_no_name("(,B);")]
-  #[case::trailing_garbage("(A,B);xyz")]
-  #[case::missing_branch_number("(A:,B);")]
-  fn newick_rejects_malformed_input(#[case] input: &str) {
-    assert!(parse_newick(input).is_err(), "expected error for input: {input:?}");
+  #[case::empty(                 "",          "Newick input is empty")]
+  #[case::only_whitespace(       "   \n  ",   "Newick input is empty")]
+  #[case::unbalanced_open(       "((A,B);",   "Newick: expected ')' or ',' at position 6, found ';'")]
+  #[case::unbalanced_close(      "A,B);",     "Newick: unexpected trailing content at position 1: ',B);'")]
+  #[case::multifurcation(        "(A,B,C);",  "Newick: internal node has 3 children; only strictly bifurcating trees are supported")]
+  #[case::unifurcation(          "(A);",      "Newick: internal node has 1 children; only strictly bifurcating trees are supported")]
+  #[case::leaf_no_name(          "(,B);",     "Newick: leaf without a name at position 1")]
+  #[case::trailing_garbage(      "(A,B);xyz", "Newick: unexpected trailing content at position 6: 'xyz'")]
+  #[case::missing_branch_number( "(A:,B);",   "Newick: expected a number after ':' at position 3")]
+  #[trace]
+  fn newick_rejects_malformed_input(#[case] input: &str, #[case] expected: &str) {
+    assert_error!(parse_newick(input), expected);
   }
 
   fn singleton(name: &str, index: usize) -> Pangraph {
@@ -352,10 +355,9 @@ mod tests {
     std::fs::write(&path, "((A,B),Z);").unwrap();
 
     let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
-    let err = build_tree_from_newick(&path, graphs).unwrap_err().to_string();
-    assert!(
-      err.contains("'Z' has no matching FASTA record"),
-      "unexpected error message: {err}"
+    assert_error!(
+      build_tree_from_newick(&path, graphs),
+      "Newick leaf 'Z' has no matching FASTA record"
     );
   }
 
@@ -366,11 +368,9 @@ mod tests {
     std::fs::write(&path, "(A,B);").unwrap();
 
     let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
-    let err = build_tree_from_newick(&path, graphs).unwrap_err().to_string();
-    assert!(err.contains("[C]"), "unexpected error message: {err}");
-    assert!(
-      err.contains("not present in the guide tree"),
-      "unexpected error message: {err}"
+    assert_error!(
+      build_tree_from_newick(&path, graphs),
+      "FASTA records [C] are not present in the guide tree"
     );
   }
 
@@ -381,10 +381,9 @@ mod tests {
     std::fs::write(&path, "((A,B),A);").unwrap();
 
     let graphs = vec![singleton("A", 0), singleton("B", 1)];
-    let err = build_tree_from_newick(&path, graphs).unwrap_err().to_string();
-    assert!(
-      err.contains("'A' has no matching FASTA record"),
-      "unexpected error message: {err}"
+    assert_error!(
+      build_tree_from_newick(&path, graphs),
+      "Newick leaf 'A' has no matching FASTA record"
     );
   }
 

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -1,0 +1,413 @@
+use crate::io::file::open_file_or_stdin;
+use crate::make_error;
+use crate::pangraph::pangraph::Pangraph;
+use crate::tree::clade::Clade;
+use crate::utils::lock::Lock;
+use eyre::{Report, WrapErr};
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::Path;
+
+/// Parse Newick text into a tree of leaf names. Internal nodes carry `None`; leaves carry
+/// `Some(name)`. Branch lengths and internal labels are accepted but ignored. Only strictly
+/// bifurcating trees are accepted.
+pub fn parse_newick(s: &str) -> Result<Lock<Clade<Option<String>>>, Report> {
+  let mut parser = Parser::new(s);
+  parser.skip_ws();
+  if parser.eof() {
+    return make_error!("Newick input is empty");
+  }
+  let root = parser.parse_subtree()?;
+  parser.skip_ws();
+  if parser.peek() == Some(';') {
+    parser.advance();
+  }
+  parser.skip_ws();
+  if !parser.eof() {
+    return make_error!(
+      "Newick: unexpected trailing content at position {}: '{}'",
+      parser.pos,
+      parser.remaining()
+    );
+  }
+  Ok(root)
+}
+
+/// Read a Newick file (transparent decompression), parse it, and attach singleton graphs
+/// to its leaves by matching FASTA `seq_name` against leaf labels.
+///
+/// Validates that the tree is strictly bifurcating and that every input genome appears
+/// exactly once as a leaf.
+pub fn build_tree_from_newick<P: AsRef<Path>>(
+  path: P,
+  graphs: Vec<Pangraph>,
+) -> Result<Lock<Clade<Option<Pangraph>>>, Report> {
+  let path = path.as_ref();
+  let path_opt: Option<&Path> = Some(path);
+  let mut reader =
+    open_file_or_stdin(&path_opt).wrap_err_with(|| format!("When opening guide tree file '{}'", path.display()))?;
+  let mut text = String::new();
+  reader
+    .read_to_string(&mut text)
+    .wrap_err_with(|| format!("When reading guide tree file '{}'", path.display()))?;
+  let name_tree = parse_newick(&text).wrap_err_with(|| format!("When parsing Newick from '{}'", path.display()))?;
+
+  let mut by_name: BTreeMap<String, Pangraph> = BTreeMap::new();
+  for graph in graphs {
+    let name = singleton_seq_name(&graph)?;
+    if by_name.insert(name.clone(), graph).is_some() {
+      return make_error!("Duplicate FASTA sequence name '{name}'");
+    }
+  }
+
+  let tree = attach_graphs(&name_tree, &mut by_name)?;
+
+  if !by_name.is_empty() {
+    let leftover = by_name.keys().cloned().collect::<Vec<_>>().join(", ");
+    return make_error!("FASTA records [{leftover}] are not present in the guide tree");
+  }
+
+  Ok(tree)
+}
+
+fn singleton_seq_name(graph: &Pangraph) -> Result<String, Report> {
+  graph
+    .paths
+    .values()
+    .next()
+    .and_then(|p| p.name.clone())
+    .ok_or_else(|| eyre::eyre!("Encountered a singleton graph without a path name"))
+}
+
+fn attach_graphs(
+  src: &Lock<Clade<Option<String>>>,
+  by_name: &mut BTreeMap<String, Pangraph>,
+) -> Result<Lock<Clade<Option<Pangraph>>>, Report> {
+  let (left_opt, right_opt, name_opt) = {
+    let g = src.read();
+    (g.left.clone(), g.right.clone(), g.data.clone())
+  };
+  match (left_opt, right_opt) {
+    (None, None) => {
+      let leaf_name = name_opt.ok_or_else(|| eyre::eyre!("Newick leaf without a name"))?;
+      let graph = by_name
+        .remove(&leaf_name)
+        .ok_or_else(|| eyre::eyre!("Newick leaf '{leaf_name}' has no matching FASTA record"))?;
+      Ok(Lock::new(Clade::new(Some(graph))))
+    },
+    (Some(l), Some(r)) => {
+      let new_left = attach_graphs(&l, by_name)?;
+      let new_right = attach_graphs(&r, by_name)?;
+      Ok(Lock::new(Clade::from_children(None, &new_left, &new_right)))
+    },
+    _ => make_error!("Internal node with only one child encountered while attaching graphs to guide tree"),
+  }
+}
+
+struct Parser<'a> {
+  input: &'a str,
+  pos: usize,
+}
+
+impl<'a> Parser<'a> {
+  fn new(input: &'a str) -> Self {
+    Self { input, pos: 0 }
+  }
+
+  fn eof(&self) -> bool {
+    self.pos >= self.input.len()
+  }
+
+  fn remaining(&self) -> &str {
+    self.input.get(self.pos..).unwrap_or("")
+  }
+
+  fn peek(&self) -> Option<char> {
+    self.remaining().chars().next()
+  }
+
+  fn advance(&mut self) {
+    if let Some(c) = self.peek() {
+      self.pos += c.len_utf8();
+    }
+  }
+
+  fn skip_ws(&mut self) {
+    while let Some(c) = self.peek() {
+      if c.is_whitespace() {
+        self.advance();
+      } else {
+        break;
+      }
+    }
+  }
+
+  fn parse_subtree(&mut self) -> Result<Lock<Clade<Option<String>>>, Report> {
+    self.skip_ws();
+    if self.peek() == Some('(') {
+      self.advance();
+      self.skip_ws();
+      let mut children = vec![self.parse_subtree()?];
+      self.skip_ws();
+      while self.peek() == Some(',') {
+        self.advance();
+        self.skip_ws();
+        children.push(self.parse_subtree()?);
+        self.skip_ws();
+      }
+      match self.peek() {
+        Some(')') => self.advance(),
+        Some(c) => {
+          return make_error!("Newick: expected ')' or ',' at position {}, found '{}'", self.pos, c);
+        },
+        None => return make_error!("Newick: unexpected end of input, expected ')'"),
+      }
+      let _internal_label = self.parse_name();
+      self.parse_branch_length()?;
+
+      if children.len() != 2 {
+        return make_error!(
+          "Newick: internal node has {} children; only strictly bifurcating trees are supported",
+          children.len()
+        );
+      }
+      let mut iter = children.into_iter();
+      let left = iter.next().unwrap();
+      let right = iter.next().unwrap();
+      Ok(Lock::new(Clade::from_children(None, &left, &right)))
+    } else {
+      let name = self
+        .parse_name()
+        .ok_or_else(|| eyre::eyre!("Newick: leaf without a name at position {}", self.pos))?;
+      self.parse_branch_length()?;
+      Ok(Lock::new(Clade::new(Some(name))))
+    }
+  }
+
+  fn parse_name(&mut self) -> Option<String> {
+    self.skip_ws();
+    if self.peek() == Some('\'') {
+      self.advance();
+      let mut name = String::new();
+      loop {
+        match self.peek() {
+          None => return None,
+          Some('\'') => {
+            self.advance();
+            if self.peek() == Some('\'') {
+              name.push('\'');
+              self.advance();
+            } else {
+              break;
+            }
+          },
+          Some(c) => {
+            name.push(c);
+            self.advance();
+          },
+        }
+      }
+      Some(name)
+    } else {
+      let mut name = String::new();
+      while let Some(c) = self.peek() {
+        if matches!(c, '(' | ')' | ',' | ':' | ';') || c.is_whitespace() {
+          break;
+        }
+        name.push(c);
+        self.advance();
+      }
+      if name.is_empty() { None } else { Some(name) }
+    }
+  }
+
+  fn parse_branch_length(&mut self) -> Result<(), Report> {
+    self.skip_ws();
+    if self.peek() == Some(':') {
+      self.advance();
+      self.skip_ws();
+      let start = self.pos;
+      while let Some(c) = self.peek() {
+        if c.is_ascii_digit() || matches!(c, '.' | 'e' | 'E' | '+' | '-') {
+          self.advance();
+        } else {
+          break;
+        }
+      }
+      if self.pos == start {
+        return make_error!("Newick: expected a number after ':' at position {}", self.pos);
+      }
+    }
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::io::fasta::FastaRecord;
+  use crate::pangraph::strand::Strand::Forward;
+  use crate::representation::seq::Seq;
+  use crate::tree::clade::WithName;
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  impl WithName for Option<String> {
+    fn name(&self) -> Option<&str> {
+      self.as_deref()
+    }
+  }
+
+  fn round_trip(input: &str) -> String {
+    parse_newick(input).unwrap().read().to_newick()
+  }
+
+  #[rstest]
+  fn newick_parses_basic_tree() {
+    assert_eq!(round_trip("((A,B),(C,D));"), "((A,B),(C,D));");
+  }
+
+  #[rstest]
+  fn newick_ignores_branch_lengths() {
+    assert_eq!(round_trip("((A:0.1,B:0.2):0.3,C:0.4);"), "((A,B),C);");
+  }
+
+  #[rstest]
+  fn newick_ignores_internal_labels() {
+    assert_eq!(round_trip("((A,B)inner,C)root;"), "((A,B),C);");
+  }
+
+  #[rstest]
+  fn newick_tolerates_whitespace_and_newlines() {
+    assert_eq!(round_trip("(\n  (A , B) ,\n  ( C, D )\n);\n"), "((A,B),(C,D));");
+  }
+
+  #[rstest]
+  fn newick_supports_quoted_names() {
+    assert_eq!(round_trip("('foo bar',B);"), "(foo bar,B);");
+  }
+
+  #[rstest]
+  fn newick_supports_doubled_quote_in_quoted_names() {
+    let tree = parse_newick("('it''s',B);").unwrap();
+    let g = tree.read();
+    let left = g.left.as_ref().unwrap().read();
+    assert_eq!(left.data.as_deref(), Some("it's"));
+  }
+
+  #[rstest]
+  fn newick_trailing_semicolon_optional() {
+    assert_eq!(round_trip("((A,B),C)"), "((A,B),C);");
+  }
+
+  #[rstest]
+  fn newick_branch_length_in_scientific_notation() {
+    assert_eq!(round_trip("(A:1e-3,B:2.5E+2);"), "(A,B);");
+  }
+
+  #[rstest]
+  #[case::empty("")]
+  #[case::only_whitespace("   \n  ")]
+  #[case::unbalanced_open("((A,B);")]
+  #[case::unbalanced_close("A,B);")]
+  #[case::multifurcation("(A,B,C);")]
+  #[case::unifurcation("(A);")]
+  #[case::leaf_no_name("(,B);")]
+  #[case::trailing_garbage("(A,B);xyz")]
+  #[case::missing_branch_number("(A:,B);")]
+  fn newick_rejects_malformed_input(#[case] input: &str) {
+    assert!(parse_newick(input).is_err(), "expected error for input: {input:?}");
+  }
+
+  fn singleton(name: &str, index: usize) -> Pangraph {
+    Pangraph::singleton(
+      FastaRecord {
+        seq_name: name.to_owned(),
+        desc: None,
+        seq: Seq::from_str("ACGT"),
+        index,
+      },
+      Forward,
+      false,
+    )
+  }
+
+  #[rstest]
+  fn build_tree_from_newick_attaches_graphs() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tree.nwk");
+    std::fs::write(&path, "((A,B),C);").unwrap();
+
+    let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
+    let tree = build_tree_from_newick(&path, graphs).unwrap();
+
+    assert!(tree.read().data.is_none());
+    let leaves = collect_leaf_names(&tree);
+    assert_eq!(leaves, vec!["A", "B", "C"]);
+  }
+
+  #[rstest]
+  fn build_tree_from_newick_errors_on_extra_leaf_in_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tree.nwk");
+    std::fs::write(&path, "((A,B),Z);").unwrap();
+
+    let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
+    let err = build_tree_from_newick(&path, graphs).unwrap_err().to_string();
+    assert!(
+      err.contains("'Z' has no matching FASTA record"),
+      "unexpected error message: {err}"
+    );
+  }
+
+  #[rstest]
+  fn build_tree_from_newick_errors_on_missing_record_in_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tree.nwk");
+    std::fs::write(&path, "(A,B);").unwrap();
+
+    let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
+    let err = build_tree_from_newick(&path, graphs).unwrap_err().to_string();
+    assert!(err.contains("[C]"), "unexpected error message: {err}");
+    assert!(
+      err.contains("not present in the guide tree"),
+      "unexpected error message: {err}"
+    );
+  }
+
+  #[rstest]
+  fn build_tree_from_newick_errors_on_duplicate_leaf() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tree.nwk");
+    std::fs::write(&path, "((A,B),A);").unwrap();
+
+    let graphs = vec![singleton("A", 0), singleton("B", 1)];
+    let err = build_tree_from_newick(&path, graphs).unwrap_err().to_string();
+    assert!(
+      err.contains("'A' has no matching FASTA record"),
+      "unexpected error message: {err}"
+    );
+  }
+
+  fn recurse_leaf_names(c: &Lock<Clade<Option<Pangraph>>>, out: &mut Vec<String>) {
+    let g = c.read();
+    match (&g.left, &g.right) {
+      (None, None) => {
+        let p = g.data.as_ref().unwrap();
+        let name = p.paths.values().next().unwrap().name.clone().unwrap();
+        out.push(name);
+      },
+      (Some(l), Some(r)) => {
+        recurse_leaf_names(l, out);
+        recurse_leaf_names(r, out);
+      },
+      _ => panic!("non-bifurcating internal node"),
+    }
+  }
+
+  fn collect_leaf_names(tree: &Lock<Clade<Option<Pangraph>>>) -> Vec<String> {
+    let mut out = vec![];
+    recurse_leaf_names(tree, &mut out);
+    out
+  }
+}

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -289,47 +289,19 @@ mod tests {
     parse_newick(input).unwrap().read().to_newick()
   }
 
+  #[rustfmt::skip]
   #[rstest]
-  fn newick_parses_basic_tree() {
-    assert_eq!(round_trip("((A,B),(C,D));"), "((A,B),(C,D));");
-  }
-
-  #[rstest]
-  fn newick_ignores_branch_lengths() {
-    assert_eq!(round_trip("((A:0.1,B:0.2):0.3,C:0.4);"), "((A,B),C);");
-  }
-
-  #[rstest]
-  fn newick_ignores_internal_labels() {
-    assert_eq!(round_trip("((A,B)inner,C)root;"), "((A,B),C);");
-  }
-
-  #[rstest]
-  fn newick_tolerates_whitespace_and_newlines() {
-    assert_eq!(round_trip("(\n  (A , B) ,\n  ( C, D )\n);\n"), "((A,B),(C,D));");
-  }
-
-  #[rstest]
-  fn newick_supports_quoted_names() {
-    assert_eq!(round_trip("('foo bar',B);"), "(foo bar,B);");
-  }
-
-  #[rstest]
-  fn newick_supports_doubled_quote_in_quoted_names() {
-    let tree = parse_newick("('it''s',B);").unwrap();
-    let g = tree.read();
-    let left = g.left.as_ref().unwrap().read();
-    assert_eq!(left.data.as_deref(), Some("it's"));
-  }
-
-  #[rstest]
-  fn newick_trailing_semicolon_optional() {
-    assert_eq!(round_trip("((A,B),C)"), "((A,B),C);");
-  }
-
-  #[rstest]
-  fn newick_branch_length_in_scientific_notation() {
-    assert_eq!(round_trip("(A:1e-3,B:2.5E+2);"), "(A,B);");
+  #[case::basic_tree(              "((A,B),(C,D));",                   "((A,B),(C,D));")]
+  #[case::branch_lengths(          "((A:0.1,B:0.2):0.3,C:0.4);",       "((A,B),C);"    )]
+  #[case::internal_labels(         "((A,B)inner,C)root;",              "((A,B),C);"    )]
+  #[case::whitespace_and_newlines( "(\n  (A , B) ,\n  ( C, D )\n);\n", "((A,B),(C,D));")]
+  #[case::quoted_names(            "('foo bar',B);",                   "(foo bar,B);"  )]
+  #[case::doubled_quote(           "('it''s',B);",                     "(it's,B);"     )]
+  #[case::trailing_semicolon(      "((A,B),C)",                        "((A,B),C);"    )]
+  #[case::scientific_notation(     "(A:1e-3,B:2.5E+2);",               "(A,B);"        )]
+  #[trace]
+  fn newick_round_trip(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(expected, round_trip(input));
   }
 
   #[rstest]

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -348,43 +348,19 @@ mod tests {
     assert_eq!(leaves, vec!["A", "B", "C"]);
   }
 
+  #[rustfmt::skip]
   #[rstest]
-  fn build_tree_from_newick_errors_on_extra_leaf_in_tree() {
+  #[case::extra_leaf(     "((A,B),Z);", &["A", "B", "C"], "Newick leaf 'Z' has no matching FASTA record")]
+  #[case::missing_record( "(A,B);",     &["A", "B", "C"], "FASTA records [C] are not present in the guide tree")]
+  #[case::duplicate_leaf( "((A,B),A);", &["A", "B"],      "Newick leaf 'A' has no matching FASTA record")]
+  #[trace]
+  fn build_tree_from_newick_rejects_invalid(#[case] newick: &str, #[case] names: &[&str], #[case] expected: &str) {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("tree.nwk");
-    std::fs::write(&path, "((A,B),Z);").unwrap();
+    std::fs::write(&path, newick).unwrap();
 
-    let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
-    assert_error!(
-      build_tree_from_newick(&path, graphs),
-      "Newick leaf 'Z' has no matching FASTA record"
-    );
-  }
-
-  #[rstest]
-  fn build_tree_from_newick_errors_on_missing_record_in_tree() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("tree.nwk");
-    std::fs::write(&path, "(A,B);").unwrap();
-
-    let graphs = vec![singleton("A", 0), singleton("B", 1), singleton("C", 2)];
-    assert_error!(
-      build_tree_from_newick(&path, graphs),
-      "FASTA records [C] are not present in the guide tree"
-    );
-  }
-
-  #[rstest]
-  fn build_tree_from_newick_errors_on_duplicate_leaf() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("tree.nwk");
-    std::fs::write(&path, "((A,B),A);").unwrap();
-
-    let graphs = vec![singleton("A", 0), singleton("B", 1)];
-    assert_error!(
-      build_tree_from_newick(&path, graphs),
-      "Newick leaf 'A' has no matching FASTA record"
-    );
+    let graphs = names.iter().enumerate().map(|(i, name)| singleton(name, i)).collect::<Vec<_>>();
+    assert_error!(build_tree_from_newick(&path, graphs), expected);
   }
 
   fn recurse_leaf_names(c: &Lock<Clade<Option<Pangraph>>>, out: &mut Vec<String>) {

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -1,18 +1,20 @@
 use crate::io::file::open_file_or_stdin;
 use crate::make_error;
 use crate::pangraph::pangraph::Pangraph;
-use crate::tree::clade::{Clade, WithName};
+use crate::tree::clade::{Clade, WithNewickName};
 use crate::utils::lock::Lock;
 use eyre::{Report, WrapErr};
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
 
-impl<T: WithName> Clade<T> {
+impl<T: WithNewickName> Clade<T> {
+  /// Serialize the (sub)tree rooted at `self` as a Newick string terminated by `;`.
+  /// Node labels come from `T::newick_name`; nodes returning `None` are emitted unlabeled.
   pub fn to_newick(&self) -> String {
-    fn recurse<T: WithName>(clade: &Clade<T>) -> String {
+    fn recurse<T: WithNewickName>(clade: &Clade<T>) -> String {
       if clade.is_leaf() {
-        String::from(clade.data.name().unwrap_or_default())
+        clade.data.newick_name().unwrap_or_default()
       } else {
         let mut newick = String::from("(");
         if let Some(left) = &clade.left {
@@ -23,8 +25,8 @@ impl<T: WithName> Clade<T> {
           newick.push_str(&recurse(&right.read()));
         }
         newick.push(')');
-        if let Some(name) = clade.data.name() {
-          newick.push_str(name);
+        if let Some(name) = clade.data.newick_name() {
+          newick.push_str(&name);
         }
         newick
       }
@@ -342,11 +344,11 @@ mod tests {
     use crate::io::fasta::FastaRecord;
     use crate::pangraph::strand::Strand::Forward;
     use crate::representation::seq::Seq;
-    use crate::tree::clade::WithName;
+    use crate::tree::clade::WithNewickName;
 
-    impl WithName for Option<String> {
-      fn name(&self) -> Option<&str> {
-        self.as_deref()
+    impl WithNewickName for Option<String> {
+      fn newick_name(&self) -> Option<String> {
+        self.clone()
       }
     }
 

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -1,12 +1,39 @@
 use crate::io::file::open_file_or_stdin;
 use crate::make_error;
 use crate::pangraph::pangraph::Pangraph;
-use crate::tree::clade::Clade;
+use crate::tree::clade::{Clade, WithName};
 use crate::utils::lock::Lock;
 use eyre::{Report, WrapErr};
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
+
+impl<T: WithName> Clade<T> {
+  pub fn to_newick(&self) -> String {
+    fn recurse<T: WithName>(clade: &Clade<T>) -> String {
+      if clade.is_leaf() {
+        String::from(clade.data.name().unwrap_or_default())
+      } else {
+        let mut newick = String::from("(");
+        if let Some(left) = &clade.left {
+          newick.push_str(&recurse(&left.read()));
+        }
+        newick.push(',');
+        if let Some(right) = &clade.right {
+          newick.push_str(&recurse(&right.read()));
+        }
+        newick.push(')');
+        if let Some(name) = clade.data.name() {
+          newick.push_str(name);
+        }
+        newick
+      }
+    }
+
+    let newick = recurse(self);
+    format!("{newick};")
+  }
+}
 
 /// Parse Newick text into a tree of leaf names. Internal nodes carry `None`; leaves carry
 /// `Some(name)`. Branch lengths and internal labels are accepted but ignored. Only strictly

--- a/packages/pangraph/src/tree/newick.rs
+++ b/packages/pangraph/src/tree/newick.rs
@@ -273,22 +273,9 @@ impl<'a> Parser<'a> {
 mod tests {
   use super::*;
   use crate::assert_error;
-  use crate::io::fasta::FastaRecord;
-  use crate::pangraph::strand::Strand::Forward;
-  use crate::representation::seq::Seq;
-  use crate::tree::clade::WithName;
+  use helpers::{collect_leaf_names, round_trip, singleton};
   use pretty_assertions::assert_eq;
   use rstest::rstest;
-
-  impl WithName for Option<String> {
-    fn name(&self) -> Option<&str> {
-      self.as_deref()
-    }
-  }
-
-  fn round_trip(input: &str) -> String {
-    parse_newick(input).unwrap().read().to_newick()
-  }
 
   #[rustfmt::skip]
   #[rstest]
@@ -321,19 +308,6 @@ mod tests {
     assert_error!(parse_newick(input), expected);
   }
 
-  fn singleton(name: &str, index: usize) -> Pangraph {
-    Pangraph::singleton(
-      FastaRecord {
-        seq_name: name.to_owned(),
-        desc: None,
-        seq: Seq::from_str("ACGT"),
-        index,
-      },
-      Forward,
-      false,
-    )
-  }
-
   #[rstest]
   fn build_tree_from_newick_attaches_graphs() {
     let dir = tempfile::tempdir().unwrap();
@@ -363,25 +337,56 @@ mod tests {
     assert_error!(build_tree_from_newick(&path, graphs), expected);
   }
 
-  fn recurse_leaf_names(c: &Lock<Clade<Option<Pangraph>>>, out: &mut Vec<String>) {
-    let g = c.read();
-    match (&g.left, &g.right) {
-      (None, None) => {
-        let p = g.data.as_ref().unwrap();
-        let name = p.paths.values().next().unwrap().name.clone().unwrap();
-        out.push(name);
-      },
-      (Some(l), Some(r)) => {
-        recurse_leaf_names(l, out);
-        recurse_leaf_names(r, out);
-      },
-      _ => panic!("non-bifurcating internal node"),
-    }
-  }
+  mod helpers {
+    use super::*;
+    use crate::io::fasta::FastaRecord;
+    use crate::pangraph::strand::Strand::Forward;
+    use crate::representation::seq::Seq;
+    use crate::tree::clade::WithName;
 
-  fn collect_leaf_names(tree: &Lock<Clade<Option<Pangraph>>>) -> Vec<String> {
-    let mut out = vec![];
-    recurse_leaf_names(tree, &mut out);
-    out
+    impl WithName for Option<String> {
+      fn name(&self) -> Option<&str> {
+        self.as_deref()
+      }
+    }
+
+    pub fn round_trip(input: &str) -> String {
+      parse_newick(input).unwrap().read().to_newick()
+    }
+
+    pub fn singleton(name: &str, index: usize) -> Pangraph {
+      Pangraph::singleton(
+        FastaRecord {
+          seq_name: name.to_owned(),
+          desc: None,
+          seq: Seq::from_str("ACGT"),
+          index,
+        },
+        Forward,
+        false,
+      )
+    }
+
+    pub fn collect_leaf_names(tree: &Lock<Clade<Option<Pangraph>>>) -> Vec<String> {
+      let mut out = vec![];
+      recurse_leaf_names(tree, &mut out);
+      out
+    }
+
+    fn recurse_leaf_names(c: &Lock<Clade<Option<Pangraph>>>, out: &mut Vec<String>) {
+      let g = c.read();
+      match (&g.left, &g.right) {
+        (None, None) => {
+          let p = g.data.as_ref().unwrap();
+          let name = p.paths.values().next().unwrap().name.clone().unwrap();
+          out.push(name);
+        },
+        (Some(l), Some(r)) => {
+          recurse_leaf_names(l, out);
+          recurse_leaf_names(r, out);
+        },
+        _ => panic!("non-bifurcating internal node"),
+      }
+    }
   }
 }

--- a/packages/pangraph/src/utils/assert.rs
+++ b/packages/pangraph/src/utils/assert.rs
@@ -7,3 +7,14 @@ macro_rules! pretty_assert_eq {
     );
   }};
 }
+
+#[macro_export]
+macro_rules! assert_error {
+  ($result:expr, $expected_message:expr) => {{
+    let Err(error) = $result else {
+      panic!("expected Err, got Ok");
+    };
+    let actual_message = $crate::utils::error::report_to_string(&error);
+    pretty_assertions::assert_eq!($expected_message, actual_message);
+  }};
+}


### PR DESCRIPTION
Add the `--guide-tree` option to `pangraph build` command to allow users to provide a custom guide tree in Newick format, bypassing kmer-based guide-tree construction