### PR TITLE
perf(pypangraph): validate loaded graphs with jsonschema-rs

### DIFF
--- a/dev/docker/python.dockerfile
+++ b/dev/docker/python.dockerfile
@@ -93,6 +93,7 @@ RUN set -euxo pipefail >/dev/null \
   'dill' \
   'ipywidgets' \
   'jsonpickle' \
+  'jsonschema-rs=0.49.9' \
   'jupyter-dash' \
   'jupyterlab' \
   'jupyterlab_widgets' \

--- a/packages/pypangraph/benchmarks/bench_load
+++ b/packages/pypangraph/benchmarks/bench_load
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Benchmark JSON load and schema-validation strategies for pypangraph graphs.
+
+Loading a pangraph graph means turning a (optionally gzipped) JSON file into a
+validated in-memory representation. This script measures each phase of that work
+and each candidate validation or decode engine, so the cost of validation can be
+compared against parsing and decompression on a single machine.
+
+The three engines that back the three ``feat/pypangraph-load-*`` branches are
+mutually exclusive in the product, but this benchmark defines self-contained
+models for all of them, so the full comparison reproduces on any branch where the
+libraries happen to be installed. Engines whose library is absent are skipped, not
+failed.
+
+Run::
+
+    python3 benchmarks/bench_load                     # default: tests/data/staph.json.gz
+    python3 benchmarks/bench_load path/to/graph.json  # a specific graph
+    python3 benchmarks/bench_load --runs 9            # more repetitions
+
+To reproduce the complete table install every engine first::
+
+    pip install jsonschema jsonschema-rs msgspec pydantic
+"""
+
+import argparse
+import gzip
+import json
+import statistics
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pypangraph.pangraph_schema import schema
+
+DEFAULT_FIXTURE = "tests/data/staph.json.gz"
+DEFAULT_RUNS = 5
+
+# A row of the results table: engine label, median milliseconds (None when the
+# engine could not run), and a short note (why it was skipped, or what it is).
+Row = tuple[str, "float | None", str]
+
+
+def main() -> None:
+    args = _parse_args()
+    path = Path(args.fixture)
+    on_disk = path.read_bytes()
+    raw_bytes = gzip.decompress(on_disk) if path.suffix == ".gz" else on_disk
+    raw_str = raw_bytes.decode()
+    obj = json.loads(raw_str)
+    graph = {"pangraph": obj}
+
+    print(f"fixture: {args.fixture}")
+    print(
+        f"compressed {len(on_disk) / 1e6:.2f} MB -> decoded {len(raw_bytes) / 1e6:.2f} MB"
+        f" | blocks={len(obj['blocks'])} nodes={len(obj['nodes'])} paths={len(obj['paths'])}"
+    )
+    print(f"median of {args.runs} runs\n")
+
+    _report(_measure(path.suffix == ".gz", on_disk, raw_bytes, raw_str, graph, args.runs))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixture", nargs="?", default=DEFAULT_FIXTURE)
+    parser.add_argument("--runs", type=int, default=DEFAULT_RUNS)
+    return parser.parse_args()
+
+
+def _measure(
+    gzipped: bool, on_disk: bytes, raw_bytes: bytes, raw_str: str, graph: dict, runs: int
+) -> list[Row]:
+    decompress: Row = (
+        ("gzip decompress", _median_ms(lambda: gzip.decompress(on_disk), runs), "stdlib")
+        if gzipped
+        else ("gzip decompress", None, "input not gzipped")
+    )
+    return [
+        decompress,
+        ("json.loads (parse)", _median_ms(lambda: json.loads(raw_str), runs), "stdlib, baseline"),
+        _row_jsonschema(graph, runs),
+        _row_jsonschema_rs(graph, runs),
+        _row_stdlib(graph, runs),
+        _row_msgspec(raw_bytes, runs),
+        _row_pydantic(raw_str, runs),
+    ]
+
+
+def _report(rows: list[Row]) -> None:
+    baseline = _baseline_ms(rows)
+    width = max(len(label) for label, _, _ in rows)
+    for label, ms, note in rows:
+        if ms is None:
+            print(f"{label:<{width}}  {'skipped':>11}   {note}")
+            continue
+        speedup = f"{baseline / ms:6.1f}x" if baseline else "     -"
+        print(f"{label:<{width}}  {ms:8.1f} ms  {speedup}  {note}")
+    if baseline:
+        print(
+            f"\nbaseline = json.loads + jsonschema (current loader) = {baseline:.1f} ms;"
+            " speedup column is baseline / row."
+        )
+
+
+def _baseline_ms(rows: list[Row]) -> float | None:
+    times = {label: ms for label, ms, _ in rows}
+    parse = times.get("json.loads (parse)")
+    validate = times.get("jsonschema (pure python)")
+    return parse + validate if parse is not None and validate is not None else None
+
+
+def _median_ms(fn: Callable[[], object], runs: int) -> float:
+    samples = [_timed(fn) for _ in range(runs)]
+    return statistics.median(samples) * 1000
+
+
+def _timed(fn: Callable[[], object]) -> float:
+    start = time.perf_counter()
+    fn()
+    return time.perf_counter() - start
+
+
+# --- JSON-schema engines: validate the parsed dict against the shared schema ---
+
+
+def _row_jsonschema(graph: dict, runs: int) -> Row:
+    try:
+        import jsonschema
+    except ImportError:
+        return ("jsonschema (pure python)", None, "not installed")
+    validator = jsonschema.Draft202012Validator(schema)
+    ms = _median_ms(lambda: validator.validate(graph), runs)
+    return ("jsonschema (pure python)", ms, "current loader")
+
+
+def _row_jsonschema_rs(graph: dict, runs: int) -> Row:
+    try:
+        import jsonschema_rs
+    except ImportError:
+        return ("jsonschema-rs (Rust)", None, "not installed")
+    validator = jsonschema_rs.validator_for(schema)
+    ms = _median_ms(lambda: validator.validate(graph), runs)
+    return ("jsonschema-rs (Rust)", ms, "drop-in, keeps dicts")
+
+
+def _row_stdlib(graph: dict, runs: int) -> Row:
+    ms = _median_ms(lambda: _stdlib_validate(graph, schema), runs)
+    return ("stdlib mini-validator", ms, "no dependency")
+
+
+# --- typed decode engines: parse and validate into typed models in one pass ---
+
+
+def _row_msgspec(raw_bytes: bytes, runs: int) -> Row:
+    try:
+        import msgspec
+    except ImportError:
+        return ("msgspec (typed decode)", None, "not installed")
+
+    uint = Annotated[int, msgspec.Meta(ge=0)]
+
+    class Sub(msgspec.Struct):
+        pos: uint
+        alt: Annotated[str, msgspec.Meta(min_length=1, max_length=1)]
+
+    class Del(msgspec.Struct):
+        pos: uint
+        len: uint
+
+    class Ins(msgspec.Struct):
+        pos: uint
+        seq: str
+
+    class Edit(msgspec.Struct):
+        subs: list[Sub]
+        dels: list[Del]
+        inss: list[Ins]
+
+    class Block(msgspec.Struct):
+        id: uint
+        consensus: str
+        alignments: dict[str, Edit]
+
+    class Path(msgspec.Struct):
+        id: uint
+        nodes: list[uint]
+        tot_len: uint
+        circular: bool
+        name: str | None = None
+        desc: str | None = None
+
+    class Node(msgspec.Struct):
+        id: uint
+        block_id: uint
+        path_id: uint
+        strand: Literal["+", "-"]
+        position: tuple[uint, uint]
+
+    class Graph(msgspec.Struct):
+        paths: dict[str, Path]
+        blocks: dict[str, Block]
+        nodes: dict[str, Node]
+
+    decoder = msgspec.json.Decoder(Graph)
+    ms = _median_ms(lambda: decoder.decode(raw_bytes), runs)
+    return ("msgspec (typed decode)", ms, "parse+validate, typed")
+
+
+def _row_pydantic(raw_str: str, runs: int) -> Row:
+    try:
+        import pydantic
+    except ImportError:
+        return ("pydantic (typed decode)", None, "not installed")
+
+    uint = Annotated[int, pydantic.Field(ge=0)]
+
+    class Sub(pydantic.BaseModel):
+        pos: uint
+        alt: Annotated[str, pydantic.Field(min_length=1, max_length=1)]
+
+    class Del(pydantic.BaseModel):
+        pos: uint
+        len: uint
+
+    class Ins(pydantic.BaseModel):
+        pos: uint
+        seq: str
+
+    class Edit(pydantic.BaseModel):
+        subs: list[Sub]
+        dels: list[Del]
+        inss: list[Ins]
+
+    class Block(pydantic.BaseModel):
+        id: uint
+        consensus: str
+        alignments: dict[str, Edit]
+
+    class Path(pydantic.BaseModel):
+        id: uint
+        nodes: list[uint]
+        tot_len: uint
+        circular: bool
+        name: str | None = None
+        desc: str | None = None
+
+    class Node(pydantic.BaseModel):
+        id: uint
+        block_id: uint
+        path_id: uint
+        strand: Literal["+", "-"]
+        position: tuple[uint, uint]
+
+    class Graph(pydantic.BaseModel):
+        paths: dict[str, Path]
+        blocks: dict[str, Block]
+        nodes: dict[str, Node]
+
+    ms = _median_ms(lambda: Graph.model_validate_json(raw_str), runs)
+    return ("pydantic (typed decode)", ms, "parse+validate, typed")
+
+
+def _stdlib_validate(node: object, sch: dict, defs: dict | None = None) -> None:
+    """Validate ``node`` against the subset of JSON Schema that this schema uses.
+
+    Supports ``$ref``, ``type`` (incl. nullable unions), ``required``,
+    ``properties``, ``additionalProperties``, ``items``, ``enum`` and ``minimum``
+    -- the keywords schemars emits for the pangraph types.
+    """
+    if defs is None:
+        defs = sch.get("$defs", {})
+    if "$ref" in sch:
+        _stdlib_validate(node, defs[sch["$ref"].split("/")[-1]], defs)
+        return
+    declared = sch.get("type")
+    if declared is not None:
+        types = declared if isinstance(declared, list) else [declared]
+        if not any(_stdlib_is(node, t) for t in types):
+            raise ValueError(f"expected {types}, got {type(node).__name__}")
+        if node is None:
+            return
+    if "enum" in sch and node not in sch["enum"]:
+        raise ValueError(f"{node!r} not in enum {sch['enum']}")
+    if isinstance(node, dict):
+        for req in sch.get("required", []):
+            if req not in node:
+                raise ValueError(f"missing required {req!r}")
+        props = sch.get("properties", {})
+        additional = sch.get("additionalProperties")
+        for key, value in node.items():
+            if key in props:
+                _stdlib_validate(value, props[key], defs)
+            elif isinstance(additional, dict):
+                _stdlib_validate(value, additional, defs)
+    elif isinstance(node, list) and isinstance(sch.get("items"), dict):
+        for item in node:
+            _stdlib_validate(item, sch["items"], defs)
+    if isinstance(node, (int, float)) and not isinstance(node, bool):
+        minimum = sch.get("minimum")
+        if minimum is not None and node < minimum:
+            raise ValueError(f"{node} < minimum {minimum}")
+
+
+def _stdlib_is(node: object, type_name: str) -> bool:
+    return {
+        "object": isinstance(node, dict),
+        "array": isinstance(node, list),
+        "string": isinstance(node, str),
+        "integer": isinstance(node, int) and not isinstance(node, bool),
+        "number": isinstance(node, (int, float)) and not isinstance(node, bool),
+        "boolean": isinstance(node, bool),
+        "null": node is None,
+    }[type_name]
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/pypangraph/docs/graph-loading.md
+++ b/packages/pypangraph/docs/graph-loading.md
@@ -1,0 +1,42 @@
+# Graph loading and validation
+
+`Pangraph.from_json` turns a pangraph JSON file (optionally gzipped) into an
+in-memory graph in three steps:
+
+1. **Read and parse.** The file is decompressed when its name ends in `.json.gz`
+   and parsed with the standard library `json` module.
+2. **Validate.** The parsed object is checked against the JSON schema in
+   `pypangraph/pangraph_schema.py`, which is generated from the Rust types that
+   produce the file. Validation failures raise `PangraphLoadError` with the
+   offending constraint.
+3. **Construct.** The validated object is split into the `paths`, `blocks` and
+   `nodes` collections that make up a `Pangraph`.
+
+## Why validation uses jsonschema-rs
+
+Validation is the dominant cost of loading. On a mid-sized graph (664 blocks,
+6817 nodes) parsing takes tens of milliseconds while a pure-Python JSON-schema
+pass over the same data takes seconds: the validator walks every node, edit and
+position in interpreted Python.
+
+The loader validates with [`jsonschema-rs`](https://pypi.org/project/jsonschema-rs/),
+a Rust-backed validator for the same schema. It compiles the schema once at import
+time (`_VALIDATOR` in `pypangraph/class_graph.py`) and reuses the compiled
+validator for every load. On the graph above this reduces the validation step from
+seconds to about ten milliseconds, so the load becomes bounded by decompression and
+parsing rather than validation. The accepted and rejected graphs are unchanged:
+`jsonschema-rs` enforces the same schema, including required fields, value types,
+the `strand` enum, and non-negative integers.
+
+## Reproducing the numbers
+
+`benchmarks/bench_load` measures each phase and every validation engine that is
+installed:
+
+```
+python3 benchmarks/bench_load                     # tests/data/staph.json.gz
+python3 benchmarks/bench_load path/to/graph.json  # a specific graph
+```
+
+Install `jsonschema jsonschema-rs msgspec pydantic` to compare all engines on one
+machine.

--- a/packages/pypangraph/pypangraph/class_graph.py
+++ b/packages/pypangraph/pypangraph/class_graph.py
@@ -1,7 +1,7 @@
 # Wrapper class to load a Pangraph object from a .json file.
 
 import json
-import jsonschema
+import jsonschema_rs
 import itertools
 import gzip
 import pandas as pd
@@ -13,6 +13,11 @@ from .class_path import PathCollection
 from .class_block import BlockCollection
 from .class_node import Nodes
 from .pangraph_schema import schema
+
+# Compile the schema once at import time. jsonschema-rs spends all its per-call
+# cost in the validation traversal, so the validator is built here and reused
+# for every load rather than recompiled on each call.
+_VALIDATOR = jsonschema_rs.validator_for(schema)
 
 
 class PangraphLoadError(ValueError):
@@ -75,10 +80,10 @@ class Pangraph:
 
         try:
             graph = {"pangraph": pan_json}
-            jsonschema.validate(instance=graph, schema=schema)
-        except jsonschema.exceptions.ValidationError as ex:
+            _VALIDATOR.validate(graph)
+        except jsonschema_rs.ValidationError as ex:
             raise PangraphLoadError(
-                f"invalid pangraph JSON in {filename}: {ex.message}"
+                f"invalid pangraph JSON in {filename}: {ex}"
             ) from ex
 
         pan = Pangraph(pan_json)

--- a/packages/pypangraph/pyproject.toml
+++ b/packages/pypangraph/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
   classifiers = ['Programming Language :: Python :: 3', 'License :: OSI Approved :: MIT License', 'Operating System :: OS Independent']
-  dependencies = ['matplotlib', 'numpy', 'pandas', 'biopython', 'jsonschema']
+  dependencies = ['matplotlib', 'numpy', 'pandas', 'biopython', 'jsonschema-rs']
   description = 'package to manipulate pangenomes produced by PanGraph'
   name = 'pypangraph'
   readme = 'README.md'

--- a/packages/pypangraph/tests/conftest.py
+++ b/packages/pypangraph/tests/conftest.py
@@ -408,3 +408,12 @@ def inversion_pangraph():
 def plasmid_pangraph():
     """The real plasmids dataset, used by smoke tests."""
     return pp.Pangraph.from_json("tests/data/plasmids.json")
+
+
+@pytest.fixture
+def junction_pangraph_json():
+    """Raw dict form of the junction pangraph, for loader and validation tests.
+
+    Function-scoped, so each test receives a fresh, independently mutable copy.
+    """
+    return build_junction_pangraph_json()

--- a/packages/pypangraph/tests/test_graph_validation.py
+++ b/packages/pypangraph/tests/test_graph_validation.py
@@ -1,0 +1,76 @@
+"""Schema-validation behaviour of ``Pangraph.from_json``.
+
+Before constructing the object, the loader validates every graph against the JSON
+schema that is generated from the Rust types. These tests lock in which graphs are
+accepted and which are rejected, so the contract holds no matter which validation
+engine backs the loader.
+
+Oracle: ``pypangraph/pangraph_schema.py`` (the schema itself). Each rejection case
+violates one named schema constraint.
+"""
+
+import json
+
+import pytest
+
+import pypangraph as pp
+
+
+def _write(tmp_path, graph):
+    fname = tmp_path / "graph.json"
+    fname.write_text(json.dumps(graph))
+    return fname
+
+
+def test_graph_validation_accepts_valid(tmp_path, junction_pangraph_json):
+    fname = _write(tmp_path, junction_pangraph_json)
+    pan = pp.Pangraph.from_json(fname)
+    assert len(pan.strains()) == 3
+
+
+def _drop_blocks(graph):
+    # Pangraph.blocks is a required property.
+    del graph["blocks"]
+
+
+def _nodes_as_list(graph):
+    # Pangraph.nodes must be an object (map), not an array.
+    graph["nodes"] = [1, 2, 3]
+
+
+def _negative_tot_len(graph):
+    # PangraphPath.tot_len is a uint (minimum 0).
+    next(iter(graph["paths"].values()))["tot_len"] = -5
+
+
+def _bad_strand(graph):
+    # Strand is the enum {"+", "-"}.
+    next(iter(graph["nodes"].values()))["strand"] = "x"
+
+
+def _missing_node_block_id(graph):
+    # PangraphNode.block_id is required.
+    del next(iter(graph["nodes"].values()))["block_id"]
+
+
+def _consensus_not_string(graph):
+    # PangraphBlock.consensus must be a string.
+    next(iter(graph["blocks"].values()))["consensus"] = 123
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(_drop_blocks, id="missing_blocks"),
+        pytest.param(_nodes_as_list, id="nodes_as_list"),
+        pytest.param(_negative_tot_len, id="negative_tot_len"),
+        pytest.param(_bad_strand, id="bad_strand_enum"),
+        pytest.param(_missing_node_block_id, id="missing_node_block_id"),
+        pytest.param(_consensus_not_string, id="consensus_not_string"),
+    ],
+)
+def test_graph_validation_rejects_malformed(tmp_path, junction_pangraph_json, mutate):
+    mutate(junction_pangraph_json)
+    fname = _write(tmp_path, junction_pangraph_json)
+    with pytest.raises(pp.PangraphLoadError, match="invalid pangraph JSON"):
+        pp.Pangraph.from_json(fname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ build
 dacite
 datamodel-code-generator
 jsonschema
+jsonschema-rs
 pydantic
 setuptools[core]


### PR DESCRIPTION
> ⚠️ **AI-generated contribution.** This pull request was implemented by an AI agent. Review the code, tests, and benchmark methodology before merging.

**Alternative PRs (mutually exclusive, merge one):**

- -> **[jsonschema-rs #201](https://github.com/neherlab/pangraph/pull/201) (you are here)**: swap the validator, keep dicts; smallest change
- [msgspec #202](https://github.com/neherlab/pangraph/pull/202): typed decode; fastest
- [pydantic #203](https://github.com/neherlab/pangraph/pull/203): typed models; most common library

## Problem

`Pangraph.from_json` validates every loaded graph against the JSON schema generated from the Rust types before building the object. On real graphs that validation, not parsing, dominates load time. Issue [#200](https://github.com/neherlab/pangraph/issues/200) reports the slowdown.

On the benchmark graph below, parsing the JSON takes about 40 ms while the pure-Python `jsonschema` pass takes about 2 seconds: the validator walks every node, edit and position in interpreted Python.

## This change

Validate with [`jsonschema-rs`](https://pypi.org/project/jsonschema-rs/), a Rust-backed validator for the same schema, compiled once at import and reused for every load. Nothing else moves: the parsed value stays a dict, the collections and the whole public API are untouched, and the set of accepted and rejected graphs is identical. The load becomes bounded by decompression and parsing instead of validation.

## Why this is the one to merge

- **Largest win per line changed.** The load goes from about 2 seconds to about 47 ms (a 42x end-to-end speedup) by changing the validator and its dependency. No new model layer, no refactor.
- **Zero API or behaviour change.** `Pangraph`, its collections, and every downstream consumer keep working against dicts exactly as before. The only observable difference is speed.
- **Lowest review and regression risk.** The diff is confined to the loader plus dependency declarations. There is nothing to get subtly wrong in a hand-built type model, and no new failure modes in downstream code.
- **Same validation, same errors.** `jsonschema-rs` enforces the identical schema (required fields, types, the `strand` enum, non-negative integers), so a graph that loaded before still loads, and a graph that was rejected before is still rejected.

If the goal is to remove the bottleneck now with the least surface area, this is the strongest choice.

## Benchmark

Fixture: `packages/pypangraph/tests/data/staph.json.gz` (664 blocks, 6817 nodes, 15 paths; 1.81 MB compressed, 9.72 MB decoded). Median of 7 runs on one machine in the project Python container, measured by `packages/pypangraph/benchmarks/bench_load`. Correctness parity was verified for every engine: each accepts the valid graph and rejects missing-field, wrong-type, negative-value and bad-strand mutations.

Full load (parse and validate together):

| loader                           | parse + validate | speedup |
| -------------------------------- | ---------------- | ------- |
| baseline (`json` + `jsonschema`) | 1989 ms          | 1x      |
| **jsonschema-rs (this PR)**      | **47 ms**        | **42x** |
| msgspec                          | 17 ms            | 117x    |
| pydantic                         | 92 ms            | 22x     |

Per-phase breakdown. Decompression and JSON parsing are shared; this PR changes only the validation step.

Shared (unchanged by this PR):

| phase           | ms  |
| --------------- | --- |
| gzip decompress | 23  |
| json parse      | 37  |

Validation step (what this PR changes):

| validator                   | ms     |
| --------------------------- | ------ |
| jsonschema (baseline)       | 1951   |
| **jsonschema-rs (this PR)** | **10** |

Methodology notes:

- Precompiling the pure-Python `jsonschema` validator does not help; the cost is the interpreted traversal, not validator construction.
- `fastjsonschema` was rejected: it errors on the schema's `format: uint` annotation.
- `format: uint` is a decorative annotation; the non-negative range is enforced by `minimum: 0`. No engine asserts on the format string.

Conclusion: validation is about 98% of load time, and every candidate removes it. `jsonschema-rs` gives the largest single-step reduction (about 200x on the validation step) while keeping the loader and its data model unchanged.

## The three alternatives

All three PRs branch from `feat/merge` and rewrite the same loader; they cannot be combined.

- **jsonschema-rs (this PR).** Swap the validator, keep dicts. One-line loader change, no downstream impact. Fastest to review, biggest win for the smallest change.
- **msgspec.** Decode JSON bytes straight into typed structs; validation is part of decoding. Fastest overall (beats parsing into a dict) and gives typed internals, at the cost of a small typed-model layer and reading the models in the collections.
- **pydantic.** Parse and validate into typed models with `model_validate_json`. Typed internals from the most widely used validation library, about 22x, same small model layer.

Pick jsonschema-rs for the minimal, lowest-risk fix; pick a typed option if typed internals are worth a model layer.

## Work items

- [x] Validate with a `jsonschema-rs` validator compiled once at import, in `pypangraph/class_graph.py`.
- [x] Declare `jsonschema-rs` in `pyproject.toml`, `requirements.txt`, and the Python container.
- [x] Add parameterized tests locking in the accept/reject contract.
- [x] Add `benchmarks/bench_load` and a graph-loading doc.

## Verify

```
./dev/docker/python bash -c 'pip install -e packages/pypangraph pytest && cd packages/pypangraph && python3 -m pytest -q'
./dev/docker/python bash -c 'cd packages/pypangraph && python3 benchmarks/bench_load'
```
