### PR TITLE
perf(pypangraph): parse graphs into typed pydantic models

### DIFF
--- a/dev/docker/python.dockerfile
+++ b/dev/docker/python.dockerfile
@@ -103,6 +103,7 @@ RUN set -euxo pipefail >/dev/null \
   'pathos' \
   'plotly' \
   'polars' \
+  'pydantic=2.13.4' \
   'scikit-learn' \
   'scipy' \
   'seaborn' \

--- a/packages/pypangraph/benchmarks/bench_load
+++ b/packages/pypangraph/benchmarks/bench_load
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Benchmark JSON load and schema-validation strategies for pypangraph graphs.
+
+Loading a pangraph graph means turning a (optionally gzipped) JSON file into a
+validated in-memory representation. This script measures each phase of that work
+and each candidate validation or decode engine, so the cost of validation can be
+compared against parsing and decompression on a single machine.
+
+The three engines that back the three ``feat/pypangraph-load-*`` branches are
+mutually exclusive in the product, but this benchmark defines self-contained
+models for all of them, so the full comparison reproduces on any branch where the
+libraries happen to be installed. Engines whose library is absent are skipped, not
+failed.
+
+Run::
+
+    python3 benchmarks/bench_load                     # default: tests/data/staph.json.gz
+    python3 benchmarks/bench_load path/to/graph.json  # a specific graph
+    python3 benchmarks/bench_load --runs 9            # more repetitions
+
+To reproduce the complete table install every engine first::
+
+    pip install jsonschema jsonschema-rs msgspec pydantic
+"""
+
+import argparse
+import gzip
+import json
+import statistics
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pypangraph.pangraph_schema import schema
+
+DEFAULT_FIXTURE = "tests/data/staph.json.gz"
+DEFAULT_RUNS = 5
+
+# A row of the results table: engine label, median milliseconds (None when the
+# engine could not run), and a short note (why it was skipped, or what it is).
+Row = tuple[str, "float | None", str]
+
+
+def main() -> None:
+    args = _parse_args()
+    path = Path(args.fixture)
+    on_disk = path.read_bytes()
+    raw_bytes = gzip.decompress(on_disk) if path.suffix == ".gz" else on_disk
+    raw_str = raw_bytes.decode()
+    obj = json.loads(raw_str)
+    graph = {"pangraph": obj}
+
+    print(f"fixture: {args.fixture}")
+    print(
+        f"compressed {len(on_disk) / 1e6:.2f} MB -> decoded {len(raw_bytes) / 1e6:.2f} MB"
+        f" | blocks={len(obj['blocks'])} nodes={len(obj['nodes'])} paths={len(obj['paths'])}"
+    )
+    print(f"median of {args.runs} runs\n")
+
+    _report(_measure(path.suffix == ".gz", on_disk, raw_bytes, raw_str, graph, args.runs))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixture", nargs="?", default=DEFAULT_FIXTURE)
+    parser.add_argument("--runs", type=int, default=DEFAULT_RUNS)
+    return parser.parse_args()
+
+
+def _measure(
+    gzipped: bool, on_disk: bytes, raw_bytes: bytes, raw_str: str, graph: dict, runs: int
+) -> list[Row]:
+    decompress: Row = (
+        ("gzip decompress", _median_ms(lambda: gzip.decompress(on_disk), runs), "stdlib")
+        if gzipped
+        else ("gzip decompress", None, "input not gzipped")
+    )
+    return [
+        decompress,
+        ("json.loads (parse)", _median_ms(lambda: json.loads(raw_str), runs), "stdlib, baseline"),
+        _row_jsonschema(graph, runs),
+        _row_jsonschema_rs(graph, runs),
+        _row_stdlib(graph, runs),
+        _row_msgspec(raw_bytes, runs),
+        _row_pydantic(raw_str, runs),
+    ]
+
+
+def _report(rows: list[Row]) -> None:
+    baseline = _baseline_ms(rows)
+    width = max(len(label) for label, _, _ in rows)
+    for label, ms, note in rows:
+        if ms is None:
+            print(f"{label:<{width}}  {'skipped':>11}   {note}")
+            continue
+        speedup = f"{baseline / ms:6.1f}x" if baseline else "     -"
+        print(f"{label:<{width}}  {ms:8.1f} ms  {speedup}  {note}")
+    if baseline:
+        print(
+            f"\nbaseline = json.loads + jsonschema (current loader) = {baseline:.1f} ms;"
+            " speedup column is baseline / row."
+        )
+
+
+def _baseline_ms(rows: list[Row]) -> float | None:
+    times = {label: ms for label, ms, _ in rows}
+    parse = times.get("json.loads (parse)")
+    validate = times.get("jsonschema (pure python)")
+    return parse + validate if parse is not None and validate is not None else None
+
+
+def _median_ms(fn: Callable[[], object], runs: int) -> float:
+    samples = [_timed(fn) for _ in range(runs)]
+    return statistics.median(samples) * 1000
+
+
+def _timed(fn: Callable[[], object]) -> float:
+    start = time.perf_counter()
+    fn()
+    return time.perf_counter() - start
+
+
+# --- JSON-schema engines: validate the parsed dict against the shared schema ---
+
+
+def _row_jsonschema(graph: dict, runs: int) -> Row:
+    try:
+        import jsonschema
+    except ImportError:
+        return ("jsonschema (pure python)", None, "not installed")
+    validator = jsonschema.Draft202012Validator(schema)
+    ms = _median_ms(lambda: validator.validate(graph), runs)
+    return ("jsonschema (pure python)", ms, "current loader")
+
+
+def _row_jsonschema_rs(graph: dict, runs: int) -> Row:
+    try:
+        import jsonschema_rs
+    except ImportError:
+        return ("jsonschema-rs (Rust)", None, "not installed")
+    validator = jsonschema_rs.validator_for(schema)
+    ms = _median_ms(lambda: validator.validate(graph), runs)
+    return ("jsonschema-rs (Rust)", ms, "drop-in, keeps dicts")
+
+
+def _row_stdlib(graph: dict, runs: int) -> Row:
+    ms = _median_ms(lambda: _stdlib_validate(graph, schema), runs)
+    return ("stdlib mini-validator", ms, "no dependency")
+
+
+# --- typed decode engines: parse and validate into typed models in one pass ---
+
+
+def _row_msgspec(raw_bytes: bytes, runs: int) -> Row:
+    try:
+        import msgspec
+    except ImportError:
+        return ("msgspec (typed decode)", None, "not installed")
+
+    uint = Annotated[int, msgspec.Meta(ge=0)]
+
+    class Sub(msgspec.Struct):
+        pos: uint
+        alt: Annotated[str, msgspec.Meta(min_length=1, max_length=1)]
+
+    class Del(msgspec.Struct):
+        pos: uint
+        len: uint
+
+    class Ins(msgspec.Struct):
+        pos: uint
+        seq: str
+
+    class Edit(msgspec.Struct):
+        subs: list[Sub]
+        dels: list[Del]
+        inss: list[Ins]
+
+    class Block(msgspec.Struct):
+        id: uint
+        consensus: str
+        alignments: dict[str, Edit]
+
+    class Path(msgspec.Struct):
+        id: uint
+        nodes: list[uint]
+        tot_len: uint
+        circular: bool
+        name: str | None = None
+        desc: str | None = None
+
+    class Node(msgspec.Struct):
+        id: uint
+        block_id: uint
+        path_id: uint
+        strand: Literal["+", "-"]
+        position: tuple[uint, uint]
+
+    class Graph(msgspec.Struct):
+        paths: dict[str, Path]
+        blocks: dict[str, Block]
+        nodes: dict[str, Node]
+
+    decoder = msgspec.json.Decoder(Graph)
+    ms = _median_ms(lambda: decoder.decode(raw_bytes), runs)
+    return ("msgspec (typed decode)", ms, "parse+validate, typed")
+
+
+def _row_pydantic(raw_str: str, runs: int) -> Row:
+    try:
+        import pydantic
+    except ImportError:
+        return ("pydantic (typed decode)", None, "not installed")
+
+    uint = Annotated[int, pydantic.Field(ge=0)]
+
+    class Sub(pydantic.BaseModel):
+        pos: uint
+        alt: Annotated[str, pydantic.Field(min_length=1, max_length=1)]
+
+    class Del(pydantic.BaseModel):
+        pos: uint
+        len: uint
+
+    class Ins(pydantic.BaseModel):
+        pos: uint
+        seq: str
+
+    class Edit(pydantic.BaseModel):
+        subs: list[Sub]
+        dels: list[Del]
+        inss: list[Ins]
+
+    class Block(pydantic.BaseModel):
+        id: uint
+        consensus: str
+        alignments: dict[str, Edit]
+
+    class Path(pydantic.BaseModel):
+        id: uint
+        nodes: list[uint]
+        tot_len: uint
+        circular: bool
+        name: str | None = None
+        desc: str | None = None
+
+    class Node(pydantic.BaseModel):
+        id: uint
+        block_id: uint
+        path_id: uint
+        strand: Literal["+", "-"]
+        position: tuple[uint, uint]
+
+    class Graph(pydantic.BaseModel):
+        paths: dict[str, Path]
+        blocks: dict[str, Block]
+        nodes: dict[str, Node]
+
+    ms = _median_ms(lambda: Graph.model_validate_json(raw_str), runs)
+    return ("pydantic (typed decode)", ms, "parse+validate, typed")
+
+
+def _stdlib_validate(node: object, sch: dict, defs: dict | None = None) -> None:
+    """Validate ``node`` against the subset of JSON Schema that this schema uses.
+
+    Supports ``$ref``, ``type`` (incl. nullable unions), ``required``,
+    ``properties``, ``additionalProperties``, ``items``, ``enum`` and ``minimum``
+    -- the keywords schemars emits for the pangraph types.
+    """
+    if defs is None:
+        defs = sch.get("$defs", {})
+    if "$ref" in sch:
+        _stdlib_validate(node, defs[sch["$ref"].split("/")[-1]], defs)
+        return
+    declared = sch.get("type")
+    if declared is not None:
+        types = declared if isinstance(declared, list) else [declared]
+        if not any(_stdlib_is(node, t) for t in types):
+            raise ValueError(f"expected {types}, got {type(node).__name__}")
+        if node is None:
+            return
+    if "enum" in sch and node not in sch["enum"]:
+        raise ValueError(f"{node!r} not in enum {sch['enum']}")
+    if isinstance(node, dict):
+        for req in sch.get("required", []):
+            if req not in node:
+                raise ValueError(f"missing required {req!r}")
+        props = sch.get("properties", {})
+        additional = sch.get("additionalProperties")
+        for key, value in node.items():
+            if key in props:
+                _stdlib_validate(value, props[key], defs)
+            elif isinstance(additional, dict):
+                _stdlib_validate(value, additional, defs)
+    elif isinstance(node, list) and isinstance(sch.get("items"), dict):
+        for item in node:
+            _stdlib_validate(item, sch["items"], defs)
+    if isinstance(node, (int, float)) and not isinstance(node, bool):
+        minimum = sch.get("minimum")
+        if minimum is not None and node < minimum:
+            raise ValueError(f"{node} < minimum {minimum}")
+
+
+def _stdlib_is(node: object, type_name: str) -> bool:
+    return {
+        "object": isinstance(node, dict),
+        "array": isinstance(node, list),
+        "string": isinstance(node, str),
+        "integer": isinstance(node, int) and not isinstance(node, bool),
+        "number": isinstance(node, (int, float)) and not isinstance(node, bool),
+        "boolean": isinstance(node, bool),
+        "null": node is None,
+    }[type_name]
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/pypangraph/docs/graph-loading.md
+++ b/packages/pypangraph/docs/graph-loading.md
@@ -1,0 +1,46 @@
+# Graph loading and validation
+
+`Pangraph.from_json` turns a pangraph JSON file (optionally gzipped) into an
+in-memory graph:
+
+1. **Read.** The file is decompressed when its name ends in `.json.gz` and read
+   as bytes.
+2. **Parse and validate.** The bytes are validated into the typed model in
+   `pypangraph/model.py` with `PangraphData.model_validate_json`. A single call
+   parses the JSON and checks structure, field types, the `strand` enum and the
+   non-negative integer ranges; a mismatch raises `PangraphLoadError`. There is
+   no separate validation step.
+3. **Construct.** The typed `PangraphData` is split into the `paths`, `blocks`
+   and `nodes` collections that make up a `Pangraph`.
+
+## Why loading parses into typed models
+
+Validation is the dominant cost of loading. On a mid-sized graph (664 blocks,
+6817 nodes) a pure-Python JSON-schema pass over the parsed data takes seconds,
+because the validator walks every node, edit and position in interpreted Python.
+
+`pydantic` parses and validates JSON in its compiled core, building the typed
+models in `model.py` in one call. On the graph above this replaces a multi-second
+validated load with about a hundred milliseconds. The models carry the schema's
+constraints (`Uint` for non-negative integers, a single-character `alt`, the
+`strand` enum), so the accepted and rejected graphs match the schema. A malformed
+document (invalid JSON) is reported as a read failure, distinct from a schema
+violation.
+
+The models are the internal representation. `Pangraph.from_json` parses into
+them; `Pangraph(pan)` also accepts a plain dict, which is validated with
+`PangraphData.model_validate`, so building a graph from an in-memory dict enforces
+the same schema as loading from a file.
+
+## Reproducing the numbers
+
+`benchmarks/bench_load` measures each phase and every validation engine that is
+installed:
+
+```
+python3 benchmarks/bench_load                     # tests/data/staph.json.gz
+python3 benchmarks/bench_load path/to/graph.json  # a specific graph
+```
+
+Install `jsonschema jsonschema-rs msgspec pydantic` to compare all engines on one
+machine.

--- a/packages/pypangraph/pypangraph/class_alignments.py
+++ b/packages/pypangraph/pypangraph/class_alignments.py
@@ -37,16 +37,16 @@ class Edits:
         self.dels = dels
 
     @staticmethod
-    def from_dict(edits: dict) -> "Edits":
+    def from_model(edit) -> "Edits":
         subs = sorted(
-            [Substitution(s["pos"], s["alt"]) for s in edits["subs"]],
+            [Substitution(s.pos, s.alt) for s in edit.subs],
             key=lambda x: x.pos,
         )
         inss = sorted(
-            [Insertion(i["pos"], i["seq"]) for i in edits["inss"]], key=lambda x: x.pos
+            [Insertion(i.pos, i.seq) for i in edit.inss], key=lambda x: x.pos
         )
         dels = sorted(
-            [Deletion(d["pos"], d["len"]) for d in edits["dels"]], key=lambda x: x.pos
+            [Deletion(d.pos, d.len) for d in edit.dels], key=lambda x: x.pos
         )
         return Edits(subs, inss, dels)
 
@@ -90,10 +90,10 @@ class Alignment:
         self.edits = edits
 
     @staticmethod
-    def from_dict(block: dict) -> "Alignment":
-        consensus = block["consensus"]
+    def from_model(block) -> "Alignment":
+        consensus = block.consensus
         edits = {
-            node_id: Edits.from_dict(e) for node_id, e in block["alignments"].items()
+            node_id: Edits.from_model(e) for node_id, e in block.alignments.items()
         }
         return Alignment(consensus, edits)
 

--- a/packages/pypangraph/pypangraph/class_block.py
+++ b/packages/pypangraph/pypangraph/class_block.py
@@ -16,12 +16,12 @@ class Block:
         self.alignment = alignment
 
     @staticmethod
-    def from_dict(block: dict) -> "Block":
+    def from_model(block) -> "Block":
         # Block ids are u64 hashes; keep them as strings internally so they never get
         # coerced to float when used as a pandas index/column (which silently corrupts
         # values above 2**53).
-        block_id = str(block["id"])
-        alignment = pga.Alignment.from_dict(block)
+        block_id = str(block.id)
+        alignment = pga.Alignment.from_model(block)
         return Block(block_id, alignment)
 
     def __len__(self):
@@ -66,6 +66,6 @@ class BlockCollection(IndexedCollection):
     """
 
     def __init__(self, pan_blocks):
-        ids = [str(block["id"]) for block in pan_blocks.values()]
-        items = [Block.from_dict(block) for block in pan_blocks.values()]
+        ids = [str(block.id) for block in pan_blocks.values()]
+        items = [Block.from_model(block) for block in pan_blocks.values()]
         IndexedCollection.__init__(self, ids, items)

--- a/packages/pypangraph/pypangraph/class_graph.py
+++ b/packages/pypangraph/pypangraph/class_graph.py
@@ -1,10 +1,9 @@
 # Wrapper class to load a Pangraph object from a .json file.
 
-import json
-import jsonschema
-import itertools
 import gzip
+import itertools
 import pandas as pd
+import pydantic
 from Bio import SeqRecord, Seq, AlignIO
 
 from collections import defaultdict
@@ -12,7 +11,7 @@ from collections import defaultdict
 from .class_path import PathCollection
 from .class_block import BlockCollection
 from .class_node import Nodes
-from .pangraph_schema import schema
+from .model import PangraphData
 
 
 class PangraphLoadError(ValueError):
@@ -27,15 +26,20 @@ class Pangraph:
     - `nodes` : each node represents a particular occurrence of a block on a path.
     """
 
-    def __init__(self, pan_json):
-        """Python calss to load the output of the Pangraph pipeline.
+    def __init__(self, pan):
+        """Build a Pangraph from the typed pangraph model or a raw dict.
 
         Args:
-            pan_json (dict): content of the .json file produced by pangraph.
+            pan: either a `model.PangraphData` (as produced by `from_json`) or a
+                plain dict in the pangraph JSON shape. A dict is validated and
+                converted to the typed model before use, so building a Pangraph
+                from an in-memory dict enforces the same schema as loading from a
+                file.
         """
-        self.paths = PathCollection(pan_json["paths"])
-        self.blocks = BlockCollection(pan_json["blocks"])
-        self.nodes = Nodes(pan_json["nodes"])
+        data = pan if isinstance(pan, PangraphData) else PangraphData.model_validate(pan)
+        self.paths = PathCollection(data.paths)
+        self.blocks = BlockCollection(data.blocks)
+        self.nodes = Nodes(data.nodes)
 
     def __repr__(self):
         return f"pangraph object with {len(self.strains())} paths, {len(self.blocks)} blocks and {len(self.nodes)} nodes"
@@ -62,27 +66,28 @@ class Pangraph:
             )
 
         try:
-            if is_gzjson:
-                with gzip.open(filename, "rt") as f:
-                    pan_json = json.load(f)
-            else:
-                with open(filename, "r") as f:
-                    pan_json = json.load(f)
-        except (OSError, gzip.BadGzipFile, json.JSONDecodeError) as ex:
+            opener = gzip.open if is_gzjson else open
+            with opener(filename, "rb") as f:
+                raw = f.read()
+        except (OSError, gzip.BadGzipFile) as ex:
             raise PangraphLoadError(
                 f"failed to load pangraph from {filename}: {ex}"
             ) from ex
 
         try:
-            graph = {"pangraph": pan_json}
-            jsonschema.validate(instance=graph, schema=schema)
-        except jsonschema.exceptions.ValidationError as ex:
+            data = PangraphData.model_validate_json(raw)
+        except pydantic.ValidationError as ex:
+            # pydantic reports malformed JSON as a `json_invalid` error, which is a
+            # read failure rather than a schema violation; keep the two distinct.
+            if any(err["type"] == "json_invalid" for err in ex.errors()):
+                raise PangraphLoadError(
+                    f"failed to load pangraph from {filename}: {ex}"
+                ) from ex
             raise PangraphLoadError(
-                f"invalid pangraph JSON in {filename}: {ex.message}"
+                f"invalid pangraph JSON in {filename}: {ex}"
             ) from ex
 
-        pan = Pangraph(pan_json)
-        return pan
+        return Pangraph(data)
 
     def strains(self):
         """Return lists of strain names"""

--- a/packages/pypangraph/pypangraph/class_node.py
+++ b/packages/pypangraph/pypangraph/class_node.py
@@ -28,11 +28,11 @@ class Nodes:
         self.df = pd.DataFrame.from_dict(
             {
                 node_id: {
-                    "block_id": str(node["block_id"]),
-                    "path_id": node["path_id"],
-                    "strand": parse_strandedness(node["strand"]),
-                    "start": node["position"][0],
-                    "end": node["position"][1],
+                    "block_id": str(node.block_id),
+                    "path_id": node.path_id,
+                    "strand": parse_strandedness(node.strand),
+                    "start": node.position[0],
+                    "end": node.position[1],
                 }
                 for node_id, node in nodes_dict.items()
             }

--- a/packages/pypangraph/pypangraph/class_path.py
+++ b/packages/pypangraph/pypangraph/class_path.py
@@ -11,12 +11,12 @@ class Path:
     """
 
     def __init__(self, pan_path):
-        self.name = pan_path["name"]
-        self.id = pan_path["id"]
-        self.circular = pan_path["circular"]
-        self.nodes = pan_path["nodes"]
-        self.nuc_len = pan_path["tot_len"]
-        self.desc = pan_path.get("desc", None)
+        self.name = pan_path.name
+        self.id = pan_path.id
+        self.circular = pan_path.circular
+        self.nodes = pan_path.nodes
+        self.nuc_len = pan_path.tot_len
+        self.desc = pan_path.desc
 
     def __len__(self):
         """Returns the number of nodes in the path"""
@@ -35,7 +35,7 @@ class PathCollection(IndexedCollection):
     """
 
     def __init__(self, pan_paths):
-        ids = [path["name"] for path in pan_paths.values()]
+        ids = [path.name for path in pan_paths.values()]
         # raise an error if there are duplicated path names
         if len(ids) != len(set(ids)):
             raise ValueError("Duplicated path names found in the input json file.")

--- a/packages/pypangraph/pypangraph/model.py
+++ b/packages/pypangraph/pypangraph/model.py
@@ -1,0 +1,71 @@
+"""Typed pydantic models for the pangraph JSON format.
+
+These models mirror the JSON schema that is generated from the Rust types (see
+``pangraph_schema.py``). ``PangraphData.model_validate_json`` parses and validates
+a graph document in one call, checking structure, field types, the ``strand`` enum
+and the non-negative integer ranges, so no separate validation step is needed.
+
+The ``Uint`` alias carries the schema's ``minimum: 0`` (uint) constraint. Classes
+are defined in dependency order so every referenced model exists at definition
+time and no forward-reference rebuild is required.
+"""
+
+from typing import Annotated, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+# uint: a non-negative integer, matching the schema's {"type": "integer",
+# "format": "uint", "minimum": 0}.
+Uint = Annotated[int, Field(ge=0)]
+
+
+class Sub(BaseModel):
+    pos: Uint
+    alt: Annotated[str, Field(min_length=1, max_length=1)]
+
+
+class Del(BaseModel):
+    pos: Uint
+    len: Uint
+
+
+class Ins(BaseModel):
+    pos: Uint
+    seq: str
+
+
+class Edit(BaseModel):
+    subs: list[Sub]
+    dels: list[Del]
+    inss: list[Ins]
+
+
+class PangraphPath(BaseModel):
+    id: Uint
+    nodes: list[Uint]
+    tot_len: Uint
+    circular: bool
+    name: Optional[str] = None
+    desc: Optional[str] = None
+
+
+class PangraphBlock(BaseModel):
+    id: Uint
+    consensus: str
+    alignments: dict[str, Edit]
+
+
+class PangraphNode(BaseModel):
+    id: Uint
+    block_id: Uint
+    path_id: Uint
+    strand: Literal["+", "-"]
+    position: tuple[Uint, Uint]
+
+
+class PangraphData(BaseModel):
+    """Root of a pangraph document: the paths, blocks and nodes, each keyed by id."""
+
+    paths: dict[str, PangraphPath]
+    blocks: dict[str, PangraphBlock]
+    nodes: dict[str, PangraphNode]

--- a/packages/pypangraph/pyproject.toml
+++ b/packages/pypangraph/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
   classifiers = ['Programming Language :: Python :: 3', 'License :: OSI Approved :: MIT License', 'Operating System :: OS Independent']
-  dependencies = ['matplotlib', 'numpy', 'pandas', 'biopython', 'jsonschema']
+  dependencies = ['matplotlib', 'numpy', 'pandas', 'biopython', 'pydantic']
   description = 'package to manipulate pangenomes produced by PanGraph'
   name = 'pypangraph'
   readme = 'README.md'

--- a/packages/pypangraph/tests/conftest.py
+++ b/packages/pypangraph/tests/conftest.py
@@ -408,3 +408,12 @@ def inversion_pangraph():
 def plasmid_pangraph():
     """The real plasmids dataset, used by smoke tests."""
     return pp.Pangraph.from_json("tests/data/plasmids.json")
+
+
+@pytest.fixture
+def junction_pangraph_json():
+    """Raw dict form of the junction pangraph, for loader and validation tests.
+
+    Function-scoped, so each test receives a fresh, independently mutable copy.
+    """
+    return build_junction_pangraph_json()

--- a/packages/pypangraph/tests/test_graph_validation.py
+++ b/packages/pypangraph/tests/test_graph_validation.py
@@ -1,0 +1,76 @@
+"""Schema-validation behaviour of ``Pangraph.from_json``.
+
+Before constructing the object, the loader validates every graph against the JSON
+schema that is generated from the Rust types. These tests lock in which graphs are
+accepted and which are rejected, so the contract holds no matter which validation
+engine backs the loader.
+
+Oracle: ``pypangraph/pangraph_schema.py`` (the schema itself). Each rejection case
+violates one named schema constraint.
+"""
+
+import json
+
+import pytest
+
+import pypangraph as pp
+
+
+def _write(tmp_path, graph):
+    fname = tmp_path / "graph.json"
+    fname.write_text(json.dumps(graph))
+    return fname
+
+
+def test_graph_validation_accepts_valid(tmp_path, junction_pangraph_json):
+    fname = _write(tmp_path, junction_pangraph_json)
+    pan = pp.Pangraph.from_json(fname)
+    assert len(pan.strains()) == 3
+
+
+def _drop_blocks(graph):
+    # Pangraph.blocks is a required property.
+    del graph["blocks"]
+
+
+def _nodes_as_list(graph):
+    # Pangraph.nodes must be an object (map), not an array.
+    graph["nodes"] = [1, 2, 3]
+
+
+def _negative_tot_len(graph):
+    # PangraphPath.tot_len is a uint (minimum 0).
+    next(iter(graph["paths"].values()))["tot_len"] = -5
+
+
+def _bad_strand(graph):
+    # Strand is the enum {"+", "-"}.
+    next(iter(graph["nodes"].values()))["strand"] = "x"
+
+
+def _missing_node_block_id(graph):
+    # PangraphNode.block_id is required.
+    del next(iter(graph["nodes"].values()))["block_id"]
+
+
+def _consensus_not_string(graph):
+    # PangraphBlock.consensus must be a string.
+    next(iter(graph["blocks"].values()))["consensus"] = 123
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(_drop_blocks, id="missing_blocks"),
+        pytest.param(_nodes_as_list, id="nodes_as_list"),
+        pytest.param(_negative_tot_len, id="negative_tot_len"),
+        pytest.param(_bad_strand, id="bad_strand_enum"),
+        pytest.param(_missing_node_block_id, id="missing_node_block_id"),
+        pytest.param(_consensus_not_string, id="consensus_not_string"),
+    ],
+)
+def test_graph_validation_rejects_malformed(tmp_path, junction_pangraph_json, mutate):
+    mutate(junction_pangraph_json)
+    fname = _write(tmp_path, junction_pangraph_json)
+    with pytest.raises(pp.PangraphLoadError, match="invalid pangraph JSON"):
+        pp.Pangraph.from_json(fname)


### PR DESCRIPTION
> ⚠️ **AI-generated contribution.** This pull request was implemented by an AI agent. Review the code, tests, and benchmark methodology before merging.

**Alternative PRs (mutually exclusive, merge one):**

- [jsonschema-rs #201](https://github.com/neherlab/pangraph/pull/201): swap the validator, keep dicts; smallest change
- [msgspec #202](https://github.com/neherlab/pangraph/pull/202): typed decode; fastest
- -> **[pydantic #203](https://github.com/neherlab/pangraph/pull/203) (you are here)**: typed models; most common library

## Problem

`Pangraph.from_json` validates every loaded graph against the JSON schema generated from the Rust types before building the object. On real graphs that validation, not parsing, dominates load time. Issue [#200](https://github.com/neherlab/pangraph/issues/200) reports the slowdown.

On the benchmark graph below, parsing the JSON takes about 40 ms while the pure-Python `jsonschema` pass takes about 2 seconds: the validator walks every node, edit and position in interpreted Python.

## This change

Parse and validate the JSON in one call with `PangraphData.model_validate_json`, building the typed model in `pypangraph/model.py` in [`pydantic`](https://docs.pydantic.dev/)'s compiled core. A malformed document (invalid JSON) is reported as a read failure, distinct from a schema violation. The models carry the schema's constraints (non-negative integers, single-character `alt`, the `strand` enum), and the path, block and node collections read the typed models. `Pangraph` still accepts a plain dict, which is validated with `PangraphData.model_validate`, so an in-memory dict enforces the same schema as a file.

## Why this is the one to merge

- **Typed internals on a foundation reviewers already know.** `pydantic` is one of the most widely used Python libraries; the model style, the `Field` constraints and the error format are familiar, so the code is approachable and easy to extend. The load still drops from about 2 seconds to about 92 ms, a 22x speedup.
- **Best-in-class validation errors.** When a graph is malformed, `pydantic` reports the exact field path, the expected type and the offending value, which makes debugging a bad graph far easier than a schema-walker's message.
- **The project is already set up for it.** `pydantic` and `datamodel-code-generator` are already in `requirements.txt`, and the Makefile already generates a Python model from the schema. This PR fits the direction the repository is already pointed.
- **Typed data model, static checks.** Attribute access replaces string keys, so a wrong field name is caught statically and editors autocomplete the model, which the dict-based option cannot offer.

If the goal is typed internals with the most familiar, best-supported validation library, this is the strongest choice.

## Benchmark

Fixture: `packages/pypangraph/tests/data/staph.json.gz` (664 blocks, 6817 nodes, 15 paths; 1.81 MB compressed, 9.72 MB decoded). Median of 7 runs on one machine in the project Python container, measured by `packages/pypangraph/benchmarks/bench_load`. Correctness parity was verified for every engine: each accepts the valid graph and rejects missing-field, wrong-type, negative-value and bad-strand mutations.

Full load (parse and validate together):

| loader                           | parse + validate | speedup |
| -------------------------------- | ---------------- | ------- |
| baseline (`json` + `jsonschema`) | 1989 ms          | 1x      |
| jsonschema-rs                    | 47 ms            | 42x     |
| msgspec                          | 17 ms            | 117x    |
| **pydantic (this PR)**           | **92 ms**        | **22x** |

Per-phase breakdown. Decompression is shared; this PR replaces JSON parsing and validation with a single typed parse.

Shared (unchanged by this PR):

| phase           | ms  |
| --------------- | --- |
| gzip decompress | 23  |

Parse and validate (what this PR changes):

| step                                        | ms     |
| ------------------------------------------- | ------ |
| json parse + jsonschema validate (baseline) | 1988   |
| **pydantic parse + validate (this PR)**     | **92** |

Methodology notes:

- Precompiling the pure-Python `jsonschema` validator does not help; the cost is the interpreted traversal, not validator construction.
- `fastjsonschema` was rejected: it errors on the schema's `format: uint` annotation.
- `format: uint` is a decorative annotation; the non-negative range is enforced by `minimum: 0`. No engine asserts on the format string.

Conclusion: validation is about 98% of load time, and every candidate removes it. `pydantic` folds parsing and validation into one compiled call that emits typed models, trading raw speed against `msgspec` for a far more common library and richer error messages.

## The three alternatives

All three PRs branch from `feat/merge` and rewrite the same loader; they cannot be combined.

- **jsonschema-rs.** Swap the validator, keep dicts. One-line loader change, no downstream impact, about 42x. The minimal, lowest-risk fix; keeps the untyped dict data model.
- **msgspec.** Decode JSON bytes straight into typed structs; validation is part of decoding. Fastest overall (about 117x) and typed, using a smaller, less common library.
- **pydantic (this PR).** Parse and validate into typed models with `model_validate_json`. Typed internals from the most widely used validation library, with the clearest error messages, about 22x.

Pick pydantic for typed internals on the most familiar foundation; pick msgspec for maximum speed, or jsonschema-rs for the smallest diff.

## Work items

- [x] Add typed `pydantic` models mirroring the schema in `pypangraph/model.py`.
- [x] Parse graphs into the models in `pypangraph/class_graph.py`; accept a dict via `model_validate`.
- [x] Keep malformed JSON distinct from schema violations in the load error.
- [x] Read the typed models in the path, block, alignment and node collections.
- [x] Declare `pydantic` in `pyproject.toml` and the Python container (already in `requirements.txt`).
- [x] Add parameterized tests locking in the accept/reject contract.
- [x] Add `benchmarks/bench_load` and a graph-loading doc.

## Possible improvements

- [ ] Generate the models from the schema with `datamodel-codegen` (as the Makefile already does for the dataclass example) so they cannot drift from the Rust types.

## Verify

```
./dev/docker/python bash -c 'pip install -e packages/pypangraph pytest && cd packages/pypangraph && python3 -m pytest -q'
./dev/docker/python bash -c 'cd packages/pypangraph && python3 benchmarks/bench_load'
```
